### PR TITLE
Fix Travis: Use clang instead of gcc. Override default script command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,24 +35,24 @@ before_install:
     fi
 
 before_script:
-  curl -sLO http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz;
-  tar zxvf icu4c-62_1-src.tgz;
-  cd icu/source;
-  chmod +x runConfigureICU configure install-sh;
-  if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./runConfigureICU Linux --enable-static --disable-shared; fi
-  if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./runConfigureICU MacOSX --enable-static --disable-shared; fi
-  make;
-  sudo make install; 
-  icu-config --version;
+  - curl -sLO http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz;
+  - tar zxvf icu4c-62_1-src.tgz;
+  - cd icu/source;
+  - chmod +x runConfigureICU configure install-sh;
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./runConfigureICU Linux --enable-static --disable-shared; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./runConfigureICU MacOSX --enable-static --disable-shared; fi
+  - make;
+  - sudo make install; 
+  - icu-config --version;
 
 script:
-  cd icu/source;
-  export ICU_LD_FLAGS=`icu-config --ldflags`;
-  export CGO_LDFLAGS="${CGO_LDFLAGS} ${ICU_LD_FLAGS}";
-  t=$(pwd);
-  cd ../..;
-  cmake -DICU_PATH=$t;
-  make;
+  - cd icu/source;
+  - export ICU_LD_FLAGS=`icu-config --ldflags`;
+  - export CGO_LDFLAGS="${CGO_LDFLAGS} ${ICU_LD_FLAGS}";
+  - t=$(pwd);
+  - cd ../..;
+  - cmake -DICU_PATH=$t;
+  - make;
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
 install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo apt-get install -qq cmake libxml2-dev libmotif-dev build-essential;
-      gcc -v && g++ -v && && make --version && cmake --version
+      gcc -v && g++ -v && make --version && cmake --version
       curl -sLO http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz;
       tar zxvf icu4c-62_1-src.tgz;
       cd icu/source;

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ compiler: gcc
 dist: trusty
 
 before_install:
+  - eval "${MATRIX_EVAL}"
   - git submodule update --init --recursive;
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo add-apt-repository ppa:beineri/opt-qt571-trusty -y;

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,39 +34,29 @@ before_install:
       brew install libxml2;
     fi
 
-script:
+before_script:
+  curl -sLO http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz;
+  tar zxvf icu4c-62_1-src.tgz;
+  cd icu/source;
+  chmod +x runConfigureICU configure install-sh;
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then  
-      curl -sLO http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz;
-      tar zxvf icu4c-62_1-src.tgz;
-      cd icu/source;
-      chmod +x runConfigureICU configure install-sh;
       ./runConfigureICU Linux  --enable-static --disable-shared;
-      make;
-      sudo make install;
-      icu-config --version;
-      export ICU_LD_FLAGS=`icu-config --ldflags`;
-      export CGO_LDFLAGS="${CGO_LDFLAGS} ${ICU_LD_FLAGS}";
-      t=$(pwd);
-      cd ../..;
-      cmake -DICU_PATH=$t;
-      make;
     fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-     curl -sLO http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz;
-     tar zxvf icu4c-62_1-src.tgz;
-     cd icu/source;
-     chmod +x runConfigureICU configure install-sh;
      ./runConfigureICU MacOSX  --enable-static --disable-shared;
-     make;
-     sudo make install;
-     icu-config --version;
+    fi
+  make;
+  sudo make install; 
+  icu-config --version;
+
+script:
+     cd icu/source;
      export ICU_LD_FLAGS=`icu-config --ldflags`;
      export CGO_LDFLAGS="${CGO_LDFLAGS} ${ICU_LD_FLAGS}";
      t=$(pwd);
      cd ../..;
      cmake -DICU_PATH=$t;
      make;
-    fi
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"     
 
 dist: trusty
-sudo: required
+sudo: true
 language:
   - cpp
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,13 @@ before_script:
   - make;
   - sudo make install; 
   - icu-config --version;
-
-script:
-  - cd icu/source;
   - export ICU_LD_FLAGS=`icu-config --ldflags`;
   - export CGO_LDFLAGS="${CGO_LDFLAGS} ${ICU_LD_FLAGS}";
-  - t=$(pwd);
-  - cd ../..;
-  - cmake -DICU_PATH=$t;
+  - export MY_DICU_PATH=$(pwd)  
+  - cd ../..;  
+
+script:
+  - cmake -DICU_PATH="${MY_DICU_PATH}";
   - make;
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,20 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
           packages:
-            - g++-4.9
+            - clang-3.6
       env:
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+        - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
     - os: osx
-      osx_image: xcode8
-      env:
-        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"     
+      osx_image: xcode8.3
 
 dist: trusty
 sudo: true
 language:
   - cpp
 compiler:
-  - gcc
+  - clang
 
 before_install:
   - eval "${MATRIX_EVAL}"
@@ -34,8 +33,7 @@ before_install:
 
 install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      sudo apt-get install -qq cmake libxml2-dev libmotif-dev build-essential;
-      gcc -v && g++ -v && make --version && cmake --version;
+      sudo apt-get install -qq cmake libxml2-dev libmotif-dev build-essential;      
       curl -sLO http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz;
       tar zxvf icu4c-62_1-src.tgz;
       cd icu/source;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,20 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-7
+            - g++-4.9
       env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
     - os: osx
       osx_image: xcode8
       env:
-        - MATRIX_EVAL="brew install gcc && CC=gcc-7 && CXX=g++-7"     
-
-sudo: true
-
-language: cpp
-compiler: gcc
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"     
 
 dist: trusty
+sudo: required
+language:
+  - cpp
+compiler:
+  - gcc
 
 before_install:
   - eval "${MATRIX_EVAL}"
@@ -35,6 +35,7 @@ before_install:
 install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo apt-get install -qq cmake libxml2-dev libmotif-dev build-essential;
+      gcc -v && g++ -v && && make --version && cmake --version
       curl -sLO http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz;
       tar zxvf icu4c-62_1-src.tgz;
       cd icu/source;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,18 @@
-os:
-  - linux
-  - osx
-osx_image: xcode8.3
+matrix:
+  include:    
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+    - os: osx
+      osx_image: xcode8
+      env:
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"         
 
 sudo: true
 
@@ -13,10 +24,7 @@ dist: trusty
 before_install:
   - git submodule update --init --recursive;
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
       sudo add-apt-repository ppa:beineri/opt-qt571-trusty -y;
-    fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo apt-get update -qq;
     fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,24 +39,20 @@ before_script:
   tar zxvf icu4c-62_1-src.tgz;
   cd icu/source;
   chmod +x runConfigureICU configure install-sh;
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then  
-      ./runConfigureICU Linux  --enable-static --disable-shared;
-    fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-     ./runConfigureICU MacOSX  --enable-static --disable-shared;
-    fi
+  if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./runConfigureICU Linux --enable-static --disable-shared; fi
+  if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./runConfigureICU MacOSX --enable-static --disable-shared; fi
   make;
   sudo make install; 
   icu-config --version;
 
 script:
-     cd icu/source;
-     export ICU_LD_FLAGS=`icu-config --ldflags`;
-     export CGO_LDFLAGS="${CGO_LDFLAGS} ${ICU_LD_FLAGS}";
-     t=$(pwd);
-     cd ../..;
-     cmake -DICU_PATH=$t;
-     make;
+  cd icu/source;
+  export ICU_LD_FLAGS=`icu-config --ldflags`;
+  export CGO_LDFLAGS="${CGO_LDFLAGS} ${ICU_LD_FLAGS}";
+  t=$(pwd);
+  cd ../..;
+  cmake -DICU_PATH=$t;
+  make;
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-4.9
+            - g++-7
       env:
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
     - os: osx
       osx_image: xcode8
       env:
-        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"         
+        - MATRIX_EVAL="brew install gcc && CC=gcc-7 && CXX=g++-7"     
 
 sudo: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,16 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo add-apt-repository ppa:beineri/opt-qt571-trusty -y;
       sudo apt-get update -qq;
+      sudo apt-get install -qq cmake libxml2-dev libmotif-dev build-essential;    
     fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       brew update;
+      brew install openmotif;
+      brew install libxml2;
     fi
 
-install:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      sudo apt-get install -qq cmake libxml2-dev libmotif-dev build-essential;      
+script:
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then  
       curl -sLO http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz;
       tar zxvf icu4c-62_1-src.tgz;
       cd icu/source;
@@ -50,8 +52,6 @@ install:
       make;
     fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-     brew install openmotif;
-     brew install libxml2;
      curl -sLO http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz;
      tar zxvf icu4c-62_1-src.tgz;
      cd icu/source;

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
 install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo apt-get install -qq cmake libxml2-dev libmotif-dev build-essential;
-      gcc -v && g++ -v && make --version && cmake --version
+      gcc -v && g++ -v && make --version && cmake --version;
       curl -sLO http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz;
       tar zxvf icu4c-62_1-src.tgz;
       cd icu/source;


### PR DESCRIPTION
> sorry, unimplemented: non-trivial designated initializers not supported

Code doesn't compile in gcc without special flags. By using clang, the code compiles. More info:

 + https://docs.travis-ci.com/user/languages/c/
 + https://stackoverflow.com/a/28721394/1926840
 + https://stackoverflow.com/a/31216136/1926840

> $ ./configure && make && make test
> /Users/travis/.travis/job_stages: line 104: ./configure: No such file or directory
> The command "./configure && make && make test" exited with 127.

According to The Docs the default script for C projects is `./configure && make && make test`. However, as specified just a couple of lines below, "This can be overridden as described in the general build configuration guide." More info:

 + https://stackoverflow.com/a/33357495/1926840