### PR TITLE
Changes to make generated xmls valid according to alto 3.1 schema.

### DIFF
--- a/src/ConstantsXML.cc
+++ b/src/ConstantsXML.cc
@@ -4,7 +4,7 @@ namespace ConstantsXML {
 	// All tags ALTO XML dialect
 	const char *TAG_ALTO = "alto";
 
-	const char *ALTO_URI = "http://www.loc.gov/standards/alto/v3/alto.xsd";
+	const char *ALTO_URI = "http://www.loc.gov/standards/alto/ns-v3#";
 
 	const char *TAG_DESCRIPTION = "Description";
     const char *TAG_MEASUREMENTUNIT = "MeasurementUnit";

--- a/src/Parameters.cc
+++ b/src/Parameters.cc
@@ -71,6 +71,12 @@ void Parameters::setReadingOrder(GBool readingOrders) {
   unlockGlobalParams;
 }
 
+void Parameters::setCharReadingOrderAttr(GBool charReadingOrderAttrs) {
+  lockGlobalParams;
+  charReadingOrderAttr = charReadingOrderAttrs;
+  unlockGlobalParams;
+}
+
 void Parameters::setOcr(GBool ocrA) {
 	lockGlobalParams;
 	ocr = ocrA;

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -72,6 +72,12 @@ public:
 	 */
 	GBool getReadingOrder() {return readingOrder;}
 
+	/** PL: Return the boolean that controls whether to include TYPE attributes to String elements to
+	 * indicate right-to-left reading order (produces non-valid ALTO)
+	 * @return <code>true</code> if the charReadingOrderAttr option is selected, <code>false</code> otherwise
+	 */
+	GBool getCharReadingOrderAttr() {return charReadingOrderAttr;}
+
 	/** Return a boolean which inform if OCR should be applied to recognize non unicode glyphs
 	 * @return <code>true</code> if the ocr option is selected, <code>false</code> otherwise
 	 */
@@ -122,6 +128,12 @@ public:
 	 */	
 	void setReadingOrder(GBool readingOrders);
 
+	/** PL: Modifiy the boolean that controls whether to include TYPE attributes to String elements to indicate
+	 * right-to-left reading order (produces non-valid ALTO)
+	 * @param charReadingOrderAttr <code>true</code> if the charReadingOrderAttr option is selected, <code>false</code> otherwise
+	 */
+	void setCharReadingOrderAttr(GBool charReadingOrderAttrs);
+
 	/** Modifiy the boolean which inform ocr should be applied or not
 	 * @param readingOrder <code>true</code> if the readingOrder option is selected, <code>false</code> otherwise
 	 */
@@ -149,6 +161,8 @@ private:
 	GBool imageInline;
 	/** PL: The value of the readingOrder option */
 	GBool readingOrder;
+	/** PL: The value of the charReadingOrderAttr option */
+	GBool charReadingOrderAttr;
 	/** The value of ocr option */
 	GBool ocr;
 	/** the count limit of files */

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -2830,6 +2830,10 @@ void TextPage::addWord(TextRawWord *word) {
 
 void TextPage::addAttributTypeReadingOrder(xmlNodePtr node, char *tmp,
                                            IWord *word) {
+    if (parameters->getCharReadingOrderAttr() == gFalse) {
+        return;
+    }
+
     int nbLeft = 0;
     int nbRight = 0;
 
@@ -4919,12 +4923,15 @@ void TextPage::dumpInReadingOrder(GBool useBlocks, GBool fullFontName) {
         snprintf(tmp, sizeof(tmp), ATTR_NUMFORMAT, listeImages[i]->getHeightImage());
         xmlNewProp(node, (const xmlChar *) ATTR_HEIGHT, (const xmlChar *) tmp);
 
-        if (listeImages[i]->getRotation() > 0){
-            xmlNewProp(node,(const xmlChar*)ATTR_ROTATION,(const xmlChar*)sTRUE);
-        }
-        else{
-            xmlNewProp(node,(const xmlChar*)ATTR_ROTATION,(const xmlChar*)sFALSE);
-        }
+        std::string rotation = std::to_string(listeImages[i]->getRotation());
+        xmlNewProp(node,(const xmlChar*)ATTR_ROTATION,(const xmlChar*)rotation.c_str());
+        //if (listeImages[i]->getRotation() > 0){
+        //    xmlNewProp(node,(const xmlChar*)ATTR_ROTATION,(const xmlChar*)sTRUE);
+        //}
+        //else{
+        //    xmlNewProp(node,(const xmlChar*)ATTR_ROTATION,(const xmlChar*)sFALSE);
+        //}
+
 //        if (listeImages[i]->isImageInline()) {
 //            xmlNewProp(node, (const xmlChar *) ATTR_INLINE, (const xmlChar *) sTRUE);
 //        }
@@ -5773,12 +5780,15 @@ void TextPage::dump(GBool useBlocks, GBool fullFontName) {
         snprintf(tmp, sizeof(tmp), ATTR_NUMFORMAT, listeImages[i]->getHeightImage());
         xmlNewProp(node, (const xmlChar *) ATTR_HEIGHT, (const xmlChar *) tmp);
 
-        if (listeImages[i]->getRotation() > 0){
-            xmlNewProp(node,(const xmlChar*)ATTR_ROTATION,(const xmlChar*)sTRUE);
-        }
-        else{
-            xmlNewProp(node,(const xmlChar*)ATTR_ROTATION,(const xmlChar*)sFALSE);
-        }
+        std::string rotation = std::to_string(listeImages[i]->getRotation());
+        xmlNewProp(node,(const xmlChar*)ATTR_ROTATION,(const xmlChar*)rotation.c_str());
+        //if (listeImages[i]->getRotation() > 0){
+        //    xmlNewProp(node,(const xmlChar*)ATTR_ROTATION,(const xmlChar*)sTRUE);
+        //}
+        //else{
+        //    xmlNewProp(node,(const xmlChar*)ATTR_ROTATION,(const xmlChar*)sFALSE);
+        //}
+
 //        if (listeImages[i]->isImageInline()) {
 //            xmlNewProp(node, (const xmlChar *) ATTR_INLINE, (const xmlChar *) sTRUE);
 //        }
@@ -5825,11 +5835,14 @@ void TextPage::dump(GBool useBlocks, GBool fullFontName) {
         snprintf(tmp, sizeof(tmp), ATTR_NUMFORMAT, svg_ymax - svg_ymin);
         xmlNewProp(node, (const xmlChar *) ATTR_HEIGHT, (const xmlChar *) tmp);
 
-        if (r > 0) {
-            xmlNewProp(node, (const xmlChar *) ATTR_ROTATION, (const xmlChar *) sTRUE);
-        } else {
-            xmlNewProp(node, (const xmlChar *) ATTR_ROTATION, (const xmlChar *) sFALSE);
-        }
+        std::string rotation = std::to_string(r);
+        xmlNewProp(node,(const xmlChar*)ATTR_ROTATION,(const xmlChar*)rotation.c_str());
+        //if (r > 0) {
+        //    xmlNewProp(node, (const xmlChar *) ATTR_ROTATION, (const xmlChar *) sTRUE);
+        //} else {
+        //    xmlNewProp(node, (const xmlChar *) ATTR_ROTATION, (const xmlChar *) sFALSE);
+        //}
+
 //        if (listeImages[i]->isImageInline()) {
 //            xmlNewProp(node, (const xmlChar *) ATTR_INLINE, (const xmlChar *) sTRUE);
 //        }
@@ -7284,8 +7297,10 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
     xmlAddChild(nodeOCRProcessingStep, nodeProcessingDate);
     time_t t;
     time(&t);
+    char tstamp[sizeof "YYYY-MM-DDTHH:MM:SSZ"];
+    strftime(tstamp, sizeof tstamp, "%FT%TZ", gmtime(&t));
     xmlNodeSetContent(nodeProcessingDate, (const xmlChar *) xmlEncodeEntitiesReentrant(
-            nodeProcessingDate->doc, (const xmlChar *) ctime(&t)));
+            nodeProcessingDate->doc, (const xmlChar *) tstamp));
 
     xmlNodePtr nodeProcessingSoftware = xmlNewNode(NULL, (const xmlChar *) TAG_PROCESSINGSOFTWARE);
     nodeProcessingSoftware->type = XML_ELEMENT_NODE;
@@ -7500,7 +7515,7 @@ void XmlAltoOutputDev::addStyles() {
         xmlNewProp(textStyleNode, (const xmlChar *) ATTR_FONTWIDTH, (const xmlChar *) tmp);
 
         sprintf(tmp, "%s", fontStyleInfo->getFontColor()->getCString());
-        xmlNewProp(textStyleNode, (const xmlChar *) ATTR_FONTCOLOR, (const xmlChar *) tmp);
+        xmlNewProp(textStyleNode, (const xmlChar *) ATTR_FONTCOLOR, (const xmlChar *) (tmp+1));
 
         delete fontStyleInfo->getFontColor();
 
@@ -7529,7 +7544,8 @@ void XmlAltoOutputDev::addStyles() {
         }
 
         sprintf(tmp, "%s", fontStyle->getCString());
-        xmlNewProp(textStyleNode, (const xmlChar *) ATTR_FONTSTYLE, (const xmlChar *) tmp);
+        if ( strcmp(tmp, "") )
+            xmlNewProp(textStyleNode, (const xmlChar *) ATTR_FONTSTYLE, (const xmlChar *) tmp);
 
         delete fontStyle;
 

--- a/src/pdfalto.cc
+++ b/src/pdfalto.cc
@@ -65,6 +65,7 @@ static GBool fullFontName = gFalse;
 static GBool noImageInline = gFalse;
 static GBool annots = gFalse;
 static GBool readingOrder = gFalse;
+static GBool charReadingOrderAttr = gFalse;
 static GBool ocr = gFalse;
 
 static char ownerPassword[33] = "\001";
@@ -98,6 +99,8 @@ static ArgDesc argDesc[] = {
                 "add blocks informations within the structure"},
         {"-readingOrder",  argFlag,   &readingOrder,    0,
                 "blocks follow the reading order"},
+        {"-charReadingOrderAttr",  argFlag,   &charReadingOrderAttr,    0,
+                "include TYPE attribute to String elements to indicate right-to-left reading order (not valid ALTO)"},
 //        {"-ocr",           argFlag,   &ocr,             0,
 //                "recognises all characters that are missing from unicode."},
         {"-fullFontName",  argFlag,   &fullFontName,    0,
@@ -213,6 +216,11 @@ int main(int argc, char *argv[]) {
     if (readingOrder) {
         parameters->setReadingOrder(gTrue);
         cmd->append("-readingOrder ");
+    }
+
+    if (charReadingOrderAttr) {
+        parameters->setCharReadingOrderAttr(gTrue);
+        cmd->append("-charReadingOrderAttr ");
     }
 
     if (ocr) {


### PR DESCRIPTION
- Fixed the xmlns to the alto required one.
- Fixed format of processingDateTime.
- Exclude '#' character in FONTCOLOR attributes.
- Exclude FONTSTYLE attribute if emtpy.
- Changed ROTATION attributes be a float indicating angle instead of a boolean.
- TYPE attributes to indicate right-to-left reading order off by default and new -charReadingOrderAttr to enable it.