### PR TITLE
Line number and finalize 0.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "xpdf-4.00"]
 	path = xpdf-4.00
 	url = https://github.com/kermitt2/xpdf-4.00
-	branch = nonumericchanamesmapping

--- a/Readme.md
+++ b/Readme.md
@@ -21,29 +21,29 @@ The latest stable version is *0.2*. Working version (master) is *0.3*.
 General usage is as follow: 
 
 ```
- pdfalto [options] <PDF-file> [<xml-file>]
-  -f <int>               : first page to convert
-  -l <int>               : last page to convert
-  -verbose               : display pdf attributes
-  -noText                : do not extract textual objects
-  -noImage               : do not extract Images (Bitmap and Vectorial)
-  -noImageInline         : do not include images inline in the stream
-  -outline               : create an outline file xml (i.e. a table of content) as additional file
-  -annotation            : create an annotations file xml as additional file
-  -blocks                : add blocks informations whithin the structure
-  -readingOrder          : blocks follow the reading order
-  -fullFontName          : fonts names are not normalized
-  -nsURI <string>        : add the specified namespace URI
-  -opw <string>          : owner password (for encrypted files)
-  -upw <string>          : user password (for encrypted files)
-  -filesLimit <int>      : limit of asset files be extracted to the value specified
-  -q                     : don't print any messages or errors
-  -v                     : print version info
-  -h                     : print usage information
-  -help                  : print usage information
-  --help                 : print usage information
-  -?                     : print usage information
-  --saveconf <string>    : save all command line parameters in the specified XML <file>
+Usage: pdfalto [options] <PDF-file> [<xml-file>]
+  -f <int>                      : first page to convert
+  -l <int>                      : last page to convert
+  -verbose                      : display pdf attributes
+  -noImage                      : do not extract Images (Bitmap and Vectorial)
+  -noImageInline                : do not include images inline in the stream
+  -outline                      : create an outline file xml
+  -annotation                   : create an annotations file xml
+  -noLineNumbers                : do not output line numbers added in manuscript-style textual documents
+  -readingOrder                 : blocks follow the reading order
+  -noText                       : do not extract textual objects (might be useful, but non-valid ALTO)
+  -charReadingOrderAttr         : include TYPE attribute to String elements to indicate right-to-left reading order (might be useful, but non-valid ALTO)
+  -fullFontName                 : fonts names are not normalized
+  -nsURI <string>               : add the specified namespace URI
+  -opw <string>                 : owner password (for encrypted files)
+  -upw <string>                 : user password (for encrypted files)
+  -filesLimit <int>             : limit of asset files be extracted
+  -q                            : don't print any messages or errors
+  -v                            : print version info
+  -h                            : print usage information
+  -help                         : print usage information
+  --help                        : print usage information
+  -?                            : print usage information
 ```
 
 In addition to the [ALTO](https://github.com/altoxml/documentation/wiki) file describing the PDF content, the following files are generated:
@@ -92,6 +92,12 @@ The executable `pdfalto` is generated in the root directory. Additionally, this 
 - see the issue tracker for further tasks
 
 # Changes
+
+New in version 0.3 (apart various bug fixes):
+
+- line number detection: line numbers (typically added for review in manuscripts/preprints) are specifically identified and not anymore mixed with content, they will be grouped in a separate block or, optionally, not outputted in the ALTO file (`noLineNumbers` option)
+
+- removal of `-blocks` option, the block information are always returned for ensuring ALTO validation (`<TextBlock>` element)
 
 New in version 0.2 (apart various bug fixes):
 

--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,7 @@ The executable `pdfalto` is generated in the root directory. Additionally, this 
 
 New in version 0.3 (apart various bug fixes):
 
-- line number detection: line numbers (typically added for review in manuscripts/preprints) are specifically identified and not anymore mixed with content, they will be grouped in a separate block or, optionally, not outputted in the ALTO file (`noLineNumbers` option)
+- line number detection: line numbers (typically added for review in manuscripts/preprints) are specifically identified and not anymore mixed with the rest of text content, they will be grouped in a separate block or, optionally, not outputted in the ALTO file (`noLineNumbers` option)
 
 - removal of `-blocks` option, the block information are always returned for ensuring ALTO validation (`<TextBlock>` element)
 

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -18,7 +18,9 @@ DEP_INSTALL_DIR=install
 
 LIBXML_URI=http://xmlsoft.org/sources/libxml2-2.9.8.tar.gz
 FREETYPE_URI=https://download.savannah.gnu.org/releases/freetype/freetype-2.9.tar.gz
-ICU_URI=http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz
+#ICU_URI=http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz
+ICU_URI=https://github.com/unicode-org/icu/releases/download/release-62-2/icu4c-62_2-src.tgz
+#ICU_URI=https://github.com/unicode-org/icu/releases/download/release-66-1/icu4c-66_1-src.tgz
 
 mkdir -p $DEP_INSTALL_DIR
 

--- a/src/Parameters.cc
+++ b/src/Parameters.cc
@@ -34,11 +34,11 @@ void Parameters::setDisplayText(GBool text) {
   unlockGlobalParams;
 }
 
-void Parameters::setDisplayBlocks(GBool block) {
+/*void Parameters::setDisplayBlocks(GBool block) {
   lockGlobalParams;
   displayBlocks = block;
   unlockGlobalParams;
-}
+}*/
 
 void Parameters::setDisplayOutline(GBool outl) {
   lockGlobalParams;
@@ -83,6 +83,12 @@ void Parameters::setOcr(GBool ocrA) {
 	unlockGlobalParams;
 }
 
+void Parameters::setNoLineNumbers(GBool noLineNumberAttrs) {
+  lockGlobalParams;
+  noLineNumbers = noLineNumberAttrs;
+  unlockGlobalParams;
+}
+
 void Parameters::saveToXML(const char *fileName,int firstPage,int lastPage){
 	char* tmp;
   	tmp=(char*)malloc(10*sizeof(char));
@@ -108,27 +114,6 @@ void Parameters::saveToXML(const char *fileName,int firstPage,int lastPage){
 	xmlAddChild(tool,name);
 	xmlAddChild(tool,version);
 	xmlAddChild(tool,desc);
-	
-// * -f <int> : first page to convert<br/>
-// * -l <int> : last page to convert<br/>
-// * -verbose : display pdf attributes<br/>
-// * -noText : do not extract textual objects<br/>
-// * -noImage : do not extract images (Bitmap and Vectorial)<br/>
-// * -noImageInline : do not include images inline in the stream<br/>
-// * -outline : create an outline file xml<br/>
-// * -annots : create an annotaitons file xml<br/>
-// * -cutPages : cut all pages in separately files<br/>
-// * -blocks : add blocks informations whithin the structure<br/>
-// * -readingOrder : blocks follow the reading order<br/>	
-// * -fullFontName : fonts names are not normalized<br/>
-// * -nsURI : add the specified namespace URI<br/>
-// * -q : don't print any messages or errors<br/>
-// * -v : print copyright and version information<br/>
-// * -h : print usage information<br/>
-// * -help : print usage information<br/>
-// * --help : print usage information<br/>
-// * -? : print usage information<br/>	
-	
 	
 	param = xmlNewNode(NULL,(const xmlChar*)TAG_PAR_PARAM);
 	xmlNewProp(param,(const xmlChar*)"name",(const xmlChar*)"first page");

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -31,6 +31,8 @@ public:
 	/** Destructor */
 	~Parameters();
   
+	// getters
+
 	/** Return a boolean which inform if the text is displayed 
 	 * @return <code>true</code> if the toText option is selected, <code>false</code> otherwise
 	 */
@@ -39,7 +41,7 @@ public:
 	/** Return a boolean which inform if blocks informations are diplayed
 	 * @return <code>true</code> if the blocks option is selected, <code>false</code> otherwise
 	 */
-	GBool getDisplayBlocks() { return displayBlocks;};
+	//GBool getDisplayBlocks() { return displayBlocks;};
 	
 	/** Return a boolean which inform if the images are displayed
 	 * @return <code>true</code> if the noImage option is not selected, <code>false</code> otherwise
@@ -88,6 +90,13 @@ public:
 	 */
 	int getFilesCountLimit() {return filesCountLimit;}
 
+	/** Return a boolean which inform if line numbers tokens are diplayed
+	 * @return <code>true</code> if the noLineNumbers option is selected, <code>false</code> otherwise
+	 */
+	GBool getNoLineNumbers() { return noLineNumbers;};
+
+	// setters
+
 	/** Modify the boolean which inform if the images are displayed
 	 * @param noImage <code>true</code> if the noImage option is not selected, <code>false</code> otherwise
 	 */
@@ -101,7 +110,7 @@ public:
 	/** Modify the boolean which inform if blocks informations are diplayed
 	 * @param noblock <code>true</code> if the blocks option is selected, <code>false</code> otherwise
 	 */	
-	void setDisplayBlocks(GBool noblock);
+	//void setDisplayBlocks(GBool noblock);
 	
 	/** Modify the boolean which inform if the bookmark is displayed
 	 * @param outline <code>true</code> if the outline option is selected, <code>false</code> otherwise
@@ -140,6 +149,11 @@ public:
 	void setOcr(GBool ocrA);
 
 	void setFilesCountLimit(int count);
+
+	/** Modify the boolean which inform if line numbers must be diplayed
+	 * @param noLineNumberAttrs <code>true</code> if the noLineNumbers option is selected, <code>false</code> otherwise
+	 */	
+	void setNoLineNumbers(GBool noLineNumberAttrs);
 	
 	void saveToXML(const char *fileName,int firstPage,int lastPage);
 	
@@ -150,7 +164,7 @@ private:
 	/** The value of the noText option */
 	GBool displayText;
 	/** The value of the blocks option */
-	GBool displayBlocks;
+	//GBool displayBlocks;
 	/** The value of the outline option */
 	GBool displayOutline;
 	/** The value of the cutPages option */
@@ -167,7 +181,8 @@ private:
 	GBool ocr;
 	/** the count limit of files */
 	int filesCountLimit;
-  
+  	/** PL: the value of the noLineNumbers option*/
+  	GBool noLineNumbers;
 };
 
 #endif /*PARAMETERS_H_*/

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -4665,7 +4665,7 @@ void TextPage::insertColumnIntoTree(TextBlock *column, TextBlock *tree) {
 }
 
 // PL: this is not used
-void TextPage::dumpInReadingOrder(GBool useBlocks, GBool fullFontName) {
+void TextPage::dumpInReadingOrder(GBool noLineNumbers, GBool fullFontName) {
     TextBlock *tree;
     TextColumn *col;
     TextParagraph *par;
@@ -4718,7 +4718,8 @@ void TextPage::dumpInReadingOrder(GBool useBlocks, GBool fullFontName) {
         col = (TextColumn *) columns->get(colIdx);
         for (parIdx = 0; parIdx < col->paragraphs->getLength(); ++parIdx) {
 
-            if (useBlocks) {
+            //if (useBlocks) 
+            {
                 nodeblocks = xmlNewNode(NULL, (const xmlChar *) TAG_BLOCK);
                 nodeblocks->type = XML_ELEMENT_NODE;
 
@@ -4916,14 +4917,14 @@ void TextPage::dumpInReadingOrder(GBool useBlocks, GBool fullFontName) {
                     free(tmp);
                 }
 
-                if (useBlocks)
-                    xmlAddChild(nodeblocks, nodeline);
-                else
-                    xmlAddChild(printSpace, nodeline);
+                //if (useBlocks)
+                xmlAddChild(nodeblocks, nodeline);
+                //else
+                //    xmlAddChild(printSpace, nodeline);
             }
 
-            if (useBlocks)
-                xmlAddChild(printSpace, nodeblocks);
+            //if (useBlocks)
+            xmlAddChild(printSpace, nodeblocks);
         }
         //(*outputFunc)(outputStream, eol, eolLen);
     }
@@ -5303,7 +5304,7 @@ bool TextPage::markLineNumber() {
     return hasLineNumber;
 }
 
-void TextPage::dump(GBool useBlocks, GBool fullFontName, vector<bool> lineNumberStatus) {
+void TextPage::dump(GBool noLineNumbers, GBool fullFontName, vector<bool> lineNumberStatus) {
     // Output the page in raw (content stream) order
     blocks = new GList(); //these are blocks in alto schema
 
@@ -5883,7 +5884,8 @@ void TextPage::dump(GBool useBlocks, GBool fullFontName, vector<bool> lineNumber
     for (parIdx = 0; parIdx < blocks->getLength(); parIdx++) {
         par = (TextParagraph *) blocks->get(parIdx);
 
-        if (useBlocks) {
+        //if (useBlocks) 
+        {
             nodeblocks = xmlNewNode(NULL, (const xmlChar *) TAG_BLOCK);
             nodeblocks->type = XML_ELEMENT_NODE;
 
@@ -6124,14 +6126,14 @@ void TextPage::dump(GBool useBlocks, GBool fullFontName, vector<bool> lineNumber
                 free(tmp);
             }
 
-            if (useBlocks)
-                xmlAddChild(nodeblocks, nodeline);
-            else
-                xmlAddChild(printSpace, nodeline);
+            //if (useBlocks)
+            xmlAddChild(nodeblocks, nodeline);
+            //else
+            //    xmlAddChild(printSpace, nodeline);
         }
 
-        if (useBlocks)
-            xmlAddChild(printSpace, nodeblocks);
+        //if (useBlocks)
+        xmlAddChild(printSpace, nodeblocks);
     }
 
     int imageCount = listeImages.size();
@@ -7556,7 +7558,7 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
     UnicodeMap *uMap;
 
     //useBlocks = parameters->getDisplayBlocks();
-    useBlocks = gTrue;
+    //useBlocks = gTrue;
     noLineNumbers = parameters->getNoLineNumbers();
     fullFontName = parameters->getFullFontName();
     noImageInline = parameters->getImageInline();
@@ -8107,9 +8109,9 @@ void XmlAltoOutputDev::endPage() {
     text->configuration();
     if (parameters->getDisplayText()) {
 //        if (readingOrder) {
-//            text->dumpInReadingOrder(useBlocks, fullFontName);
+//            text->dumpInReadingOrder(noLineNumbers, fullFontName);
 //        } else
-        text->dump(useBlocks, fullFontName, lineNumberStatus);
+        text->dump(noLineNumbers, fullFontName, lineNumberStatus);
         appendLineNumberStatus(text->getLineNumber());
     }
 

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -5112,8 +5112,11 @@ bool TextPage::markLineNumber() {
             rightMostBoundary = par->xMax;
     }
 
-    if (!hasLineNumber)
+    if (!hasLineNumber) {
+        delete lineNumberWords;
+        delete textWords;
         return false;
+    }
 
     // define the x alignment by clustering identified number tokens by x position
     vector<vector<int>> clusters;
@@ -5203,8 +5206,11 @@ bool TextPage::markLineNumber() {
         }
     }
 
-    if (bestClusterIndex == -1)
+    if (bestClusterIndex == -1) {
+        delete lineNumberWords;
+        delete textWords;
         return false;
+    }
 
     vector<int> bestCluster = clusters[bestClusterIndex];
     double final_vpos = positions[bestClusterIndex];
@@ -5258,8 +5264,11 @@ bool TextPage::markLineNumber() {
         }
     }
 
-    if (!hasLineNumber)
+    if (!hasLineNumber) {
+        delete lineNumberWords;
+        delete textWords;
         return false;
+    }
 
     //cout << "leftMostBoundary: " << leftMostBoundary << endl;
     //cout << "rightMostBoundary: " << rightMostBoundary << endl;
@@ -5270,8 +5279,11 @@ bool TextPage::markLineNumber() {
     if (quarterWidth+leftMostBoundary < final_vpos && final_vpos < leftMostBoundary+(quarterWidth*3))
         hasLineNumber = false;
     
-    if (!hasLineNumber)
+    if (!hasLineNumber) {
+        delete lineNumberWords;
+        delete textWords;
         return false;
+    }
 
     // increment? it's not possible to suppose any particular increments, it could be 1 by 1 or 
     // 5 by 5 for instance, however number should be growing!
@@ -5284,6 +5296,9 @@ bool TextPage::markLineNumber() {
         // consider only aligned tokens
         word->setLineNumber(true);
     }
+
+    delete lineNumberWords;
+    delete textWords;
 
     return hasLineNumber;
 }

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -5194,9 +5194,9 @@ bool TextPage::markLineNumber() {
             bestClusterIndex.push_back(i);
             largestClusterSize.push_back(theCluster.size());
         } else {
-            vector<int>::const_iterator it1 = bestClusterIndex.begin();
-            vector<int>::const_iterator it2 = largestClusterSize.begin();
-            vector<int>::const_iterator last = bestClusterIndex.end();
+            vector<int>::iterator it1 = bestClusterIndex.begin();
+            vector<int>::iterator it2 = largestClusterSize.begin();
+            vector<int>::iterator last = bestClusterIndex.end();
             int j = 0;
             while(it1 != last) {
                 if (theCluster.size() < largestClusterSize[j]) {

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -9372,8 +9372,7 @@ void XmlAltoOutputDev::initOutline(int nbPage) {
     globalParams->setTextEncoding((char *) ENCODING_UTF8);
     docOutlineRoot = xmlNewNode(NULL, (const xmlChar *) TAG_TOCITEMS);
     sprintf(tmp, "%d", nbPage);
-    xmlNewProp(docOutlineRoot, (const xmlChar *) ATTR_NB_PAGES,
-               (const xmlChar *) tmp);
+    xmlNewProp(docOutlineRoot, (const xmlChar *) ATTR_NB_PAGES, (const xmlChar *) tmp);
     xmlDocSetRootElement(docOutline, docOutlineRoot);
 }
 
@@ -9496,7 +9495,7 @@ GBool XmlAltoOutputDev::dumpOutline(xmlNodePtr parentNode, GList *itemsA, PDFDoc
         return 0;
     }
     int i;
-    GString *title;
+    //GString *title;
 
     nodeTocItem = xmlNewNode(NULL, (const xmlChar *) TAG_TOCITEMLIST);
     sprintf(tmp, "%d", levelA);
@@ -9511,12 +9510,12 @@ GBool XmlAltoOutputDev::dumpOutline(xmlNodePtr parentNode, GList *itemsA, PDFDoc
     xmlAddChild(parentNode, nodeTocItem);
 
     for (i = 0; i < itemsA->getLength(); ++i) {
-
-        title = new GString();
+        GString* title = new GString();
 
         ((OutlineItem *) itemsA->get(i))->open(); // open the kids
         dumpFragment(((OutlineItem *) itemsA->get(i))->getTitle(), ((OutlineItem *) itemsA->get(i))->getTitleLength(),
                      uMapA, title);
+
         //printf("%s\n",title->getCString());
         LinkActionKind kind;
 
@@ -9536,7 +9535,6 @@ GBool XmlAltoOutputDev::dumpOutline(xmlNodePtr parentNode, GList *itemsA, PDFDoc
         y2 = 0;
 
         if (((OutlineItem *) itemsA->get(i))->getAction()) {
-
             switch (kind = ((OutlineItem *) itemsA->get(i))->getAction()->getKind()) {
 
                 // GOTO action
@@ -9587,8 +9585,8 @@ GBool XmlAltoOutputDev::dumpOutline(xmlNodePtr parentNode, GList *itemsA, PDFDoc
 
                     // LAUNCH action
                 case actionLaunch:
-                    fileName = ((LinkLaunch *) ((OutlineItem *) itemsA->get(i))->getAction())->getFileName();
-                    delete fileName;
+                    //fileName = ((LinkLaunch *) ((OutlineItem *) itemsA->get(i))->getAction())->getFileName();
+                    //delete fileName;
                     break;
 
                     // URI action
@@ -9665,11 +9663,11 @@ GBool XmlAltoOutputDev::dumpOutline(xmlNodePtr parentNode, GList *itemsA, PDFDoc
         int idItemCurrent = idItemToc;
         idItemToc++;
         if (((OutlineItem *) itemsA->get(i))->hasKids()) {
-            dumpOutline(nodeItem, ((OutlineItem *) itemsA->get(i))->getKids(), docA, uMapA, levelA + 1,
-                        idItemCurrent);
+            dumpOutline(nodeItem, ((OutlineItem *) itemsA->get(i))->getKids(), docA, uMapA, levelA + 1, idItemCurrent);
         }
 
         delete title;
+
         ((OutlineItem *) itemsA->get(i))->close(); // close the kids
 
         atLeastOne = gTrue;

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -828,9 +828,6 @@ TextRawWord::TextRawWord(GfxState *state, double x0, double y0,
     serif = gFalse;
     symbolic = gFalse;
 
-    // the raw word is a line number
-    lineNumber = gFalse;
-
     double *fontm;
     double m[4];
     double m2[4];
@@ -1052,10 +1049,6 @@ TextRawWord::~TextRawWord() {
 }
 
 Unicode TextRawWord::getChar(int idx) { return ((TextChar *) chars->get(idx))->c; }
-
-void TextRawWord::setLineNumber(GBool theBool) {
-    lineNumber = theBool;
-}
 
 void TextRawWord::addChar(GfxState *state, double x, double y, double dx,
                           double dy, Unicode u, CharCode charCodeA, int charPosA, GBool overlap, TextFontInfo *fontA,
@@ -1827,6 +1820,16 @@ TextPage::~TextPage() {
     }
 }
 
+/** Set if the page contains a column of line numbers*/
+void TextPage::setLineNumber(GBool theBool) {
+    lineNumber = theBool;
+}
+
+/** get the presence of a column of line numbers in the text page */
+GBool TextPage::getLineNumber() {
+    return lineNumber;
+}
+
 void TextPage::startPage(int pageNum, GfxState *state, GBool cut) {
     clear();
     words = new GList();
@@ -1844,7 +1847,6 @@ void TextPage::startPage(int pageNum, GfxState *state, GBool cut) {
     PDFRectangle *trimBox = myCat->getPage(pageNum)->getTrimBox();
     PDFRectangle *bleedBox = myCat->getPage(pageNum)->getBleedBox();
     PDFRectangle *artBox = myCat->getPage(pageNum)->getArtBox();
-
 
     page = xmlNewNode(NULL, (const xmlChar *) TAG_PAGE);
     page->type = XML_ELEMENT_NODE;
@@ -5242,10 +5244,6 @@ void TextPage::markLineNumber() {
 
     if (!hasLineNumber)
         return;
-
-    //cout << "final alignment vpos: " << final_vpos << endl;
-    //cout << "        leftMostNonTrivialTextCluster: " << leftMostNonTrivialTextCluster << 
-    //    ", rightMostNonTrivialTextCluster: " << rightMostNonTrivialTextCluster << endl;
 
     // neutralize candidate line numbers in the middle of a page with 2 columns 
     // (these are ref numbers in the biblio or something else, but can't be line numbers)

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -5081,7 +5081,6 @@ bool TextPage::markLineNumber() {
 
                 // numerical token?
                 if (is_number(word)) {
-                    //cout << "line number! " << word->xMin <<  " " << word->xMax<< endl;
                     lineNumberWords->append(word);
                     hasLineNumber = true;
                 } else {
@@ -5254,8 +5253,6 @@ bool TextPage::markLineNumber() {
     if (nonTrivialClusterSize == 0)
         nonTrivialClusterSize = 1;
 
-    //cout << "bestClusterIndex.size(): " << bestClusterIndex.size() << endl;
-
     for(int j=0; j<bestClusterIndex.size(); j++) {
         bestCluster = clusters[bestClusterIndex[j]];
         final_vpos = positions[bestClusterIndex[j]];
@@ -5271,7 +5268,6 @@ bool TextPage::markLineNumber() {
                 word = (TextWord *)textWords->get(theCluster[0]);
                 int vpos1 = word->xMin;
                 int vpos2 = word->xMax;
-                //cout << "vpos1: " << vpos1 << ", vpos2: " << vpos2 << endl;
                 if (vpos1 <= final_vpos && vpos2 >= final_vpos) {
                     hasLineNumber = false;
                     break;
@@ -6452,11 +6448,9 @@ GBool TextPage::addBlockInReadingOrder(TextParagraph * block, double fontSize, G
 
     if (notInserted) {
         blocks->append(block);
-//cout << "append" << endl;
         return gFalse;
     } else {
-        blocks->insert(insertIndex, block);// be ware , the order can be the opposite if next block in next column..
-//cout << "prev inserted" << endl;
+        blocks->insert(insertIndex, block); // beware, the order can be the opposite if next block in next column..
         return gTrue;
     }
 }

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -2640,7 +2640,7 @@ void TextPage::addCharToPageChars(GfxState *state, double x, double y, double dx
 void TextPage::addCharToRawWord(GfxState *state, double x, double y, double dx,
                                 double dy, CharCode c, int nBytes, Unicode *u, int uLen, SplashFont *splashFont,
                                 GBool isNonUnicodeGlyph) {
-
+    //cout << "addCharToRawWord" << endl;
     double x1, y1, w1, h1, dx2, dy2, base, sp, delta;
     GBool overlap;
     int i;
@@ -2665,14 +2665,14 @@ void TextPage::addCharToRawWord(GfxState *state, double x, double y, double dx,
         return;
     }
 
-    // subtract char and word spacing from the dx,dy values // HD why ??
+    // subtract char and word spacing from the dx,dy values 
     sp = state->getCharSpace();
     if (c == (CharCode) 0x20) {
         sp += state->getWordSpace();
     }
     state->textTransformDelta(sp * state->getHorizScaling(), 0, &dx2, &dy2);
-    dx -= dx2; //HD
-    dy -= dy2; //HD
+    dx -= dx2; 
+    dy -= dy2; 
     state->transformDelta(dx, dy, &w1, &h1);
 
     // check the tiny chars limit
@@ -2743,7 +2743,7 @@ void TextPage::addCharToRawWord(GfxState *state, double x, double y, double dx,
                                                                            - curWord->base) <
                                                                       dupMaxSecDelta * curWord->fontSize;
 
-        //Avoid splitting token when overlaping is surrounded by diacritic
+        // avoid splitting token when overlaping is surrounded by diacritic
         ModifierClass modifierClass = NOT_A_MODIFIER;
         if (curWord->len > 0)
             modifierClass = classifyChar(((TextChar *) curWord->chars->get(curWord->getLength() - 1))->c);
@@ -2820,7 +2820,6 @@ void TextPage::addChar(GfxState *state, double x, double y, double dx,
 
 void TextPage::endWord() {
     // This check is needed because Type 3 characters can contain
-    // This check is needed because Type 3 characters can contain
     // text-drawing operations (when TextPage is being used via
     // {X,Win}SplashOutputDev rather than TextOutputDev).
     if (nest > 0) {
@@ -2834,7 +2833,6 @@ void TextPage::endWord() {
         curWord = NULL;
         idWORD++;
     }
-
 }
 
 void TextPage::addWord(TextRawWord *word) {
@@ -2884,7 +2882,6 @@ void TextPage::addAttributTypeReadingOrder(xmlNodePtr node, char *tmp,
 
 void TextPage::addAttributsNodeVerbose(xmlNodePtr node, char *tmp,
                                        IWord *word) {
-
     GString *id = new GString("p");
     xmlNewProp(node, (const xmlChar *) ATTR_SID, (const xmlChar *) buildSID(num, word->getIdx(), id)->getCString());
     delete id;
@@ -2912,7 +2909,6 @@ void TextPage::addAttributsNodeVerbose(xmlNodePtr node, char *tmp,
 
 void TextPage::addAttributsNode(xmlNodePtr node, IWord *word, TextFontStyleInfo *fontStyleInfo, UnicodeMap *uMap,
                                 GBool fullFontName) {
-
     char *tmp;
     tmp = (char *) malloc(10 * sizeof(char));
 
@@ -3161,9 +3157,7 @@ void TextPage::testLinkedText(xmlNodePtr node, double xMin, double yMin, double 
 
 }
 
-
-GBool
-TextPage::testOverlap(double x11, double y11, double x12, double y12, double x21, double y21, double x22, double y22) {
+GBool TextPage::testOverlap(double x11, double y11, double x12, double y12, double x21, double y21, double x22, double y22) {
     return ((min(x12, x22) >= max(x11, x21)) &&
             (min(y12, y22) >= max(y11, y21)));
 }
@@ -3236,27 +3230,26 @@ GBool TextFontStyleInfo::cmp(TextFontStyleInfo *tsi) {
     )
             )
         return gTrue;
-    else return gFalse;
+    else 
+        return gFalse;
 }
 
 //------------------------------------------------------------------------
 // TextGap
 //------------------------------------------------------------------------
-
 class TextGap {
-public:
 
+public:
     TextGap(double aXY, double aW) : xy(aXY), w(aW) {}
 
-    double xy;            // center of gap: x for vertical gaps,
-    //   y for horizontal gaps
-    double w;            // width of gap
+    double xy;  // center of gap: x for vertical gaps,
+                //   y for horizontal gaps
+    double w;   // width of gap
 };
 
 //------------------------------------------------------------------------
 // TextPage: layout analysis
 //------------------------------------------------------------------------
-
 // Determine primary (most common) rotation value.  Rotate all chars
 // to that primary rotation.
 int TextPage::rotateChars(GList *charsA) {
@@ -6160,7 +6153,6 @@ void TextPage::dump(GBool noLineNumbers, GBool fullFontName, vector<bool> lineNu
                 }
                 addAttributsNode(node, word, fontStyleInfo, uMap, fullFontName);
                 addAttributTypeReadingOrder(node, tmp, word);
-                // PL: not clear why reading order? we are working with stream order here
 
 //                    encodeFragment(line->text, n, uMap, primaryLR, s);
 //                    if (lineIdx + 1 < par->lines->getLength() && !line->hyphenated) {
@@ -6778,7 +6770,6 @@ void TextPage::doPathForClip(GfxPath *path, GfxState *state,
 }
 
 void TextPage::doPath(GfxPath *path, GfxState *state, GString *gattributes) {
-
     // Increment the absolute object index
     idx++;
     //printf("path %d\n",idx);
@@ -7536,7 +7527,6 @@ void file_write_data(png_structp png_ptr, png_bytep data, png_size_t length) {
         png_error(png_ptr, "Write Error");
 }
 
-//------------------------------------------------------------
 
 void file_flush_data(png_structp png_ptr) {
     FILE *file = (FILE *) png_ptr->io_ptr;
@@ -7633,11 +7623,9 @@ bool TextPage::save_png(GString *file_name,
 }
 
 
-
 //------------------------------------------------------------------------
 // XmlAltoOutputDev
 //------------------------------------------------------------------------
-
 XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
                                    Catalog *catalog, GBool physLayoutA, GBool verboseA, GString *nsURIA,
                                    GString *cmdA) {
@@ -7750,7 +7738,6 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
     }
 
     xmlDocSetRootElement(doc, docroot);
-
 
     // here we add basic structure : see https://www.loc.gov/standards/alto/techcenter/structure.html
     xmlNodePtr nodeDescription = xmlNewNode(NULL, (const xmlChar *) TAG_DESCRIPTION);
@@ -8284,8 +8271,8 @@ void XmlAltoOutputDev::startDoc(XRef *xrefA) {
 }
 
 class SplashOutFontFileID : public SplashFontFileID {
-public:
 
+public:
     SplashOutFontFileID(Ref *rA) {
         r = *rA;
         substIdx = -1;
@@ -8308,7 +8295,6 @@ public:
     int getSubstIdx() { return substIdx; }
 
 private:
-
     Ref r;
     double oblique;
     int substIdx;
@@ -8886,8 +8872,6 @@ void XmlAltoOutputDev::updateCTM(GfxState *state, double m11, double m12,
 //------------------------------------------------------------------------
 // T3FontCache
 //------------------------------------------------------------------------
-
-
 T3FontCache::T3FontCache(Ref *fontIDA, double m11A, double m12A,
                          double m21A, double m22A,
                          int glyphXA, int glyphYA, int glyphWA, int glyphHA,
@@ -9500,9 +9484,7 @@ int XmlAltoOutputDev::dumpFragment(Unicode *text, int len, UnicodeMap *uMap,
 
 GBool XmlAltoOutputDev::dumpOutline(xmlNodePtr parentNode, GList *itemsA, PDFDoc *docA, UnicodeMap *uMapA,
                                     int levelA, int idItemTocParentA) {
-
     // store them in a list
-
     xmlNodePtr nodeTocItem = NULL;
     xmlNodePtr nodeItem = NULL;
     xmlNodePtr nodeString = NULL;
@@ -9721,7 +9703,7 @@ void XmlAltoOutputDev::tilingPatternFill(GfxState *state, Gfx *gfx,
 }
 
 /**
- * Checks if the unicode sequence is utf8 complied
+ * Checks if the unicode sequence is valid utf8 
  * @param u unicode sequence
  * @param uLen
  * @return true it is complied

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -4979,6 +4979,7 @@ void TextPage::dumpInReadingOrder(GBool noLineNumbers, GBool fullFontName) {
 }
 
 bool is_digit(Unicode u) {
+    // simply match Unicode for ASCII digit... should we add more unicode variants of numbers?
     if (u == (Unicode) 48 ||
         u == (Unicode) 49 ||
         u == (Unicode) 50 ||
@@ -4999,7 +5000,6 @@ bool is_number(TextWord *word) {
     text = (Unicode *) grealloc(text, word->len * sizeof(Unicode));
     for (int i = 0; i < word->len; i++) {
         Unicode theU = ((TextChar *) word->chars->get(i))->c;
-        //cout << theU << endl;
         if (!is_digit(theU)) {
             return false;
         }
@@ -5008,7 +5008,6 @@ bool is_number(TextWord *word) {
 }
 
 int find_index(vector<double> positions, double val) {
-    //cout << "find_index: " << val << endl;
     // simple double look-up, return index of val or -1
     int index = -1;
     for (int i = 0; i < positions.size(); i++) {
@@ -5017,13 +5016,10 @@ int find_index(vector<double> positions, double val) {
             break;
         }
     }
-
-    //cout << "       found: " << index << endl;
     return index;
 }
 
 int find_index(vector<int> positions, int val) {
-    //cout << "find_index: " << val << endl;
     // simple int look-up, return index of val or -1
     int index = -1;
     for (int i = 0; i < positions.size(); i++) {
@@ -5032,8 +5028,6 @@ int find_index(vector<int> positions, int val) {
             break;
         }
     }
-
-    //cout << "       found: " << index << endl;
     return index;
 }
 
@@ -5193,15 +5187,12 @@ bool TextPage::markLineNumber() {
         }
     }
 
-    //cout << "clusters size: " << clusters.size() << endl;
-
     vector<int> bestClusterIndex;
     vector<int> largestClusterSize;
     int nonTrivialClusterSize = 3;
-    // select largest cluster of numbers, which will give the best x alignment and the corresponding list of number tokens
+    // select largest cluster of numbers, which will give the best x alignments and the corresponding lists of number tokens
     for (int i = 0; i < clusters.size(); i++) {
         vector<int> theCluster = clusters[i];
-        //cout << "theCluster.size(): " << theCluster.size() << endl;
 
         if (theCluster.size() < nonTrivialClusterSize)
             continue;
@@ -5222,8 +5213,7 @@ bool TextPage::markLineNumber() {
                         break;
                     }            
                 } else {
-                    // insert just before j
-                    //cout << "insert just before j: " << theCluster.size() << endl;
+                    // this is sorted based on the cluster siez, so we insert just before j
                     bestClusterIndex.insert(it1, i);
                     largestClusterSize.insert(it2, theCluster.size());
                     break;
@@ -5250,25 +5240,23 @@ bool TextPage::markLineNumber() {
     // check the remaining constraints: 
 
     // same font? we normally never have line number using different font
-    /*int font_size = 0;
-    xmlChar *xcFontName;
+    /*
     for (int i = 0; i < bestCluster.size(); i++) {
         int index = bestCluster[i];
         word = (TextWord *)lineNumberWords->get(index);
+        int font_size = 0;
+        xmlChar *xcFontName;
         font_size = word->fontSize;    
-    
         if (word->getFontName())
             xcFontName = (xmlChar *) word->getFontName();
+        // to be finished if needed...
+    }
+    if (!hasLineNumber)
+        return false;
+    */
 
-        if (font_size != 0 && xcFontName != NULL)
-            break;
-    }*/
-
-    //if (!hasLineNumber)
-    //    return false;
-
-    // text areas at same alignment or more "side-positioned"?
-    // see the left-most and right-most non trivial text block with the text token clusters
+    // Do we have text areas at same alignment or positioned more on the side than the number cluster?
+    // -> see the left-most and right-most non trivial text block with the text token clusters
     nonTrivialClusterSize = largestClusterSize[0] / 4;
     if (nonTrivialClusterSize == 0)
         nonTrivialClusterSize = 1;
@@ -5280,7 +5268,7 @@ bool TextPage::markLineNumber() {
         final_vpos = positions[bestClusterIndex[j]];
         hasLineNumber = true;
 
-        //cout << "move to best" << endl;
+        //cout << "move to next best" << endl;
         //cout << "     final alignment vpos: " << final_vpos << endl;
         //cout << "     nb numbers best cluster: " << bestCluster.size() << endl;
 
@@ -5307,9 +5295,6 @@ bool TextPage::markLineNumber() {
         return false;
     }
 
-    //cout << "leftMostBoundary: " << leftMostBoundary << endl;
-    //cout << "rightMostBoundary: " << rightMostBoundary << endl;
-
     // neutralize candidate line numbers in the middle of a page with 2 columns 
     // (these are ref numbers in the biblio or something else, but can't be line numbers)
     int quarterWidth = (rightMostBoundary - leftMostBoundary) / 4;
@@ -5324,9 +5309,11 @@ bool TextPage::markLineNumber() {
 
     // increment? it's not possible to suppose any particular increments, it could be 1 by 1 or 
     // 5 by 5 for instance, however number should be growing!
+    // to be done if needed...
 
     // immediate vertigal gap? 
 
+    // final marking of TextWord corresponding to line numbers
     for (int i = 0; i < bestCluster.size(); i++) {
         int index = bestCluster[i];
         word = (TextWord *)lineNumberWords->get(index);

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -7555,7 +7555,9 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
     myCatalog = catalog;
     UnicodeMap *uMap;
 
-    useBlocks = parameters->getDisplayBlocks();
+    //useBlocks = parameters->getDisplayBlocks();
+    useBlocks = gTrue;
+    noLineNumbers = parameters->getNoLineNumbers();
     fullFontName = parameters->getFullFontName();
     noImageInline = parameters->getImageInline();
 

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -78,8 +78,8 @@ struct T3FontCacheTag {
 };
 
 class T3FontCache {
-public:
 
+public:
     T3FontCache(Ref *fontID, double m11A, double m12A,
                 double m21A, double m22A,
                 int glyphXA, int glyphYA, int glyphWA, int glyphHA,
@@ -104,25 +104,16 @@ public:
     Guchar *cacheData;        // glyph pixmap cache
     T3FontCacheTag *cacheTags;    // cache tags, i.e., char codes
 };
-//------------------------------------------------------------------------
 
+//------------------------------------------------------------------------
 typedef void (*TextOutputFunc)(void *stream, char *text, int len);
 
 //------------------------------------------------------------------------
 // TextFontInfo
 //------------------------------------------------------------------------
-/**
- * TextFontInfo class (based on TextOutputDev.h, Copyright 1997-2003 Glyph & Cog, LLC)<br></br>
- * Xerox Research Centre Europe <br></br>
- * @date 04-2006
- * @author Herv� D�jean
- * @author Sophie Andrieu
- * @version xpdf 3.01
- */
-
 class TextFontInfo {
-public:
 
+public:
     TextFontInfo(GfxState *state);
     ~TextFontInfo();
 
@@ -141,7 +132,6 @@ public:
 //#endif
 
 private:
-
     Ref fontID;
     GfxFont *gfxFont;
 //#if TEXTOUT_WORD_LIST
@@ -158,10 +148,9 @@ private:
 };
 
 
-
 class TextFontStyleInfo {
-public:
 
+public:
     ~TextFontStyleInfo();
 
     // Get the font name (which may be NULL).
@@ -201,7 +190,6 @@ public:
 //#endif
 
 private:
-
     int id;
     GString* fontName;
     double fontSize;
@@ -251,16 +239,10 @@ private:
 //------------------------------------------------------------------------
 // ImageInline
 //------------------------------------------------------------------------
-/**
- * ImageInline class <br></br>
- * Xerox Research Centre Europe <br></br>
- * @date 04-2006
- * @author Sophie Andrieu
- * @version xpdf 3.01
- */
-class ImageInline {
-public:
 
+class ImageInline {
+
+public:
     /** Construct a new <code>ImageInline</code><br></br>
      * An <code>ImageInline</code> is an image which is localized in the stream and it is composed<br></br>
      * by a x position, a y position, a width, a height and href which get the path of this image.<br></br>
@@ -327,7 +309,6 @@ public:
     void setHrefImage(GString *href){hrefImage = href;}
 
 private:
-
     /** The absolute object index in the stream **/
     int idx;
     /** The x position of the image */
@@ -354,8 +335,8 @@ private:
 
 
 class Image {
-public:
 
+public:
     /** Construct a new <code>Image</code><br></br>
      * An <code>Image</code> is an image which is localized in the stream and it is composed<br></br>
      * by a x position, a y position, a width, a height and href which get the path of this image.<br></br>
@@ -445,7 +426,6 @@ public:
     void setType(GString *typeA){type = typeA;}
 
 private:
-
     /** The absolute object index in the stream **/
     int idx;
     /** The x position of the image */
@@ -480,10 +460,9 @@ private:
 //------------------------------------------------------------------------
 // TextChar
 //------------------------------------------------------------------------
-
 class TextChar {
-public:
 
+public:
     TextChar(GfxState *state, Unicode cA, CharCode charCodeA, int charPosA, int charLenA,
              double xMinA, double yMinA, double xMaxA, double yMaxA,
              int rotA, GBool clippedA, GBool invisibleA,
@@ -516,8 +495,8 @@ public:
 // IWord
 //------------------------------------------------------------------------
 class IWord {
-public:
 
+public:
     /** The id of the word (used to include and localize the image inline in the stream) */
     int idWord;
 
@@ -596,8 +575,6 @@ public:
     float leading;
 
     GBool isNonUnicodeGlyph;
-//public:
-
 
     /** Get the absolute object index in the stream
      * @return The absolute object index in the stream */
@@ -625,8 +602,9 @@ public:
      * @param r The Red color value
      * @param g The Green color value
      * @param b The Blue color value */
-    void getColor(double *r, double *g, double *b)
-    { *r = colorR; *g = colorG; *b = colorB; }
+    void getColor(double *r, double *g, double *b) { 
+        *r = colorR; *g = colorG; *b = colorB; 
+    }
 
     /** Normalize the font name :<br></br>
      *  - remove the prefix (if it is present) which is the basefont of subsetted fonts.
@@ -679,10 +657,9 @@ public:
 //------------------------------------------------------------------------
 // TextWord
 //------------------------------------------------------------------------
-
 class TextWord : public IWord {
-public:
 
+public:
     TextWord(GList *chars, int start, int lenA,
              int rotA, int dirA, GBool spaceAfterA, GfxState *state,
              TextFontInfo *fontA, double fontSizeA, int idCurrentWord,
@@ -705,7 +682,6 @@ public:
     void setLineNumber(GBool theBool);
 
 private:
-
     TextWord(TextWord *word);
     static int cmpYX(const void *p1, const void *p2);
     static int cmpCharPos(const void *p1, const void *p2);
@@ -718,7 +694,7 @@ private:
 
     GBool invisible;		// set for invisible text (render mode 3)
 
-    GBool lineNumber = gFalse;;
+    GBool lineNumber = gFalse;
 
     friend class TextBlock;
     friend class TextLine;
@@ -728,16 +704,9 @@ private:
 //------------------------------------------------------------------------
 // TextRawWord
 //------------------------------------------------------------------------
-/**
- * TextRawWord class<br></br>
- * Represents the words as a character sequence from stream order separated by a space character (U+0020) each word pointing to next one<br></br>
- * @date 07-2018
- * @author Achraf Azhar
- * @version xpdf 3.01 */
-
 class TextRawWord : public IWord {
-public:
 
+public:
     /** Construct a new <code>TextRawWord</code>
      * @param state The state description
      * @param rotA The rotation value of the current word
@@ -789,16 +758,10 @@ public:
 
     Unicode getChar(int idx);
 
-    // if the word token is a line number
-    void setLineNumber(GBool theBool);
-
 //private:
-
     /** Rank in the original flow */
     int indexmin;
     int indexmax;
-
-    GBool lineNumber;
 
     friend class TextPage;
 };
@@ -807,8 +770,8 @@ public:
 //------------------------------------------------------------------------
 // TextLine
 //------------------------------------------------------------------------
-
 class TextLine {
+
 public:
     TextLine();
     TextLine(GList *wordsA, double xMinA, double yMinA,
@@ -831,8 +794,8 @@ public:
     void setYMax(double yMaxA) { yMax = yMaxA; }
     void setWords(GList *wordsA) { words = wordsA; }
     void setFontSize(double fontSizeA) { fontSize = fontSizeA; }
-private:
 
+private:
     static int cmpX(const void *p1, const void *p2);
 
     GList *words;			// [TextWord]
@@ -860,8 +823,8 @@ private:
 //------------------------------------------------------------------------
 // TextParagraph
 //------------------------------------------------------------------------
-
 class TextParagraph {
+
 public:
     TextParagraph();
     TextParagraph(GList *linesA, GBool dropCapA);
@@ -883,7 +846,6 @@ public:
     void setLines(GList *linesA) { lines = linesA; }
 
 private:
-
     GList *lines;			// [TextLine]
     GBool dropCap;		// paragraph starts with a drop capital
     double xMin, xMax;		// bounding box x coordinates
@@ -895,10 +857,9 @@ private:
 //------------------------------------------------------------------------
 // TextColumn
 //------------------------------------------------------------------------
-
 class TextColumn {
-public:
 
+public:
     TextColumn(GList *paragraphsA, double xMinA, double yMinA,
                double xMaxA, double yMaxA);
     ~TextColumn();
@@ -914,7 +875,6 @@ public:
     int getRotation();
 
 private:
-
     static int cmpX(const void *p1, const void *p2);
     static int cmpY(const void *p1, const void *p2);
     static int cmpPX(const void *p1, const void *p2);
@@ -931,22 +891,12 @@ private:
 };
 
 
-
 //------------------------------------------------------------------------
 // TextPage
 //------------------------------------------------------------------------
-/**
- * TextPage class (based on TextOutputDev.h, Copyright 1997-2003 Glyph & Cog, LLC)<br></br>
- * Xerox Research Centre Europe <br></br>
- * @date 04-2006
- * @author Herv� D�jean
- * @author Sophie Andrieu
- * @version xpdf 3.01
- */
-
 class TextPage {
-public:
 
+public:
     /** Construct a new <code>TextPage</code>
      * @param verboseA The value of the verbose option
      * @param node The root node
@@ -1106,8 +1056,7 @@ public:
 
     void buildSuperLines(TextBlock *blk, GList *superLines);
 
-    void assignSimpleLayoutPositions(GList *superLines,
-                                               UnicodeMap *uMap);
+    void assignSimpleLayoutPositions(GList *superLines, UnicodeMap *uMap);
 
     void generateUnderlinesAndLinks(GList *columns);
 
@@ -1201,8 +1150,13 @@ public:
     /** Identify line numbers and mark corresponding raw word */
     void markLineNumber();
 
-//  void addLink(int xMin, int yMin, int xMax, int yMax, Link *link);
+    /** Set if the page contains a column of line numbers*/
+    void setLineNumber(GBool theBool);
 
+    /** get the presence of a column of line numbers in the text page */
+    GBool getLineNumber();
+
+//  void addLink(int xMin, int yMin, int xMax, int yMax, Link *link);
 
     //from mobi
     const char* drawImageOrMask(GfxState *state, Object* ref, Stream *str,
@@ -1216,8 +1170,6 @@ public:
                    unsigned char* data,
                    unsigned char bpp = 24, unsigned char color_type = PNG_COLOR_TYPE_RGB,
                    png_color* palette = NULL, unsigned short color_count = 0);
-
-
 
     /** Draw the image
      * @param state The state description
@@ -1282,7 +1234,6 @@ public:
 //    TextRawWord * getRawWords(){ return rawWords;}
 
 private:
-
     /** Clear all */
     void clear();
 
@@ -1344,8 +1295,6 @@ private:
     GBool testAnnotatedText(double xMin,double yMin,double xMax,double yMax);
     void testLinkedText(xmlNodePtr node,double xMin,double yMin,double xMax,double yMax);
 
-
-
     /** The numero of the current <i>PAGE</i> */
     int num;
     /** The <i>IMAGE</i> numero in the current page */
@@ -1399,8 +1348,7 @@ private:
     /** The directory name which contain all data */
     GString *dataDirectory;
 
-    /**   */
-
+    /** */
     void *vecOutputStream;
 
     /** PL: To modify the blocks in reading order */
@@ -1478,18 +1426,20 @@ private:
 
 
     GList *getChars(GList *charsA, double xMin, double yMin, double xMax, double yMax);
-//
+
+    ModifierClass classifyChar(Unicode u);
+
+    Unicode getCombiningDiacritic(ModifierClass modifierClass);
+
+    /** if the page contains a column of line numbers */
+    GBool lineNumber = gFalse;
+
 //    friend class TextBlock;
 //    friend class TextColumn;
 //    friend class TextLine;
 //    friend class TextRawWord;
 //    friend class TextWord;
-
-    ModifierClass classifyChar(Unicode u);
-
-    Unicode getCombiningDiacritic(ModifierClass modifierClass);
 };
-
 
 // Simple class to save picture references
 class PictureReference
@@ -1510,24 +1460,12 @@ public:
 };
 
 
-
-
 //------------------------------------------------------------------------
 // XmlAltoOutputDev
 //------------------------------------------------------------------------
-/**
- * XmlAltoOutputDev.h (based on TextOutputDev.h, Copyright 1997-2003 Glyph & Cog, LLC)<br></br>
- * Xerox Research Centre Europe <br></br>
- * @date 04-2006
- * @author Herv� D�jean
- * @author Sophie Andrieu
- * @version xpdf 3.01
- * @see OutputDev
- */
-
 class XmlAltoOutputDev: public OutputDev {
-public:
 
+public:
     /**
      * Construct a new <code>XmlOutputDev</code><br></br>
      * Open a text output file. If <i>fileName</i> is NULL, no file is written
@@ -1654,7 +1592,6 @@ public:
                                int width, int height, GBool invert, GBool inlineImg,
                                GBool interpolate);
 
-
 //    virtual void drawImageMask(GfxState *state, Object *ref, Stream *str,
 //    int width, int height, GBool invert,
 //    GBool inlineImg, GBool interpolate);
@@ -1688,7 +1625,6 @@ public:
 //
 //    void writeImageInfo(int width, int height, GfxState *state,
 //                                          GfxImageColorMap *colorMap);
-
 
 
     virtual void drawSoftMaskedImage(GfxState *state, Object *ref,
@@ -1777,7 +1713,6 @@ public:
                                      double m31, double m32);
 
 private:
-
     /** Generate the path
      * @param path The current path
      * @param state The state description
@@ -1787,12 +1722,10 @@ private:
     double curstate[6];//this is the ctm
     //double *curstate[1000];
 
-
     /** The XML document */
     xmlDocPtr  doc;
     /** The root node */
     xmlNodePtr docroot;
-
 
     /** The XML document outline */
     xmlDocPtr  docOutline;
@@ -1816,7 +1749,7 @@ private:
     GBool verbose;
     /** To keep text in content stream order */
     //GBool rawOrder;
-/** To make text in reading order */
+    /** To make text in reading order */
     GBool readingOrder;
     /** To know if the blocks option is selected */
     GBool useBlocks;
@@ -1845,7 +1778,6 @@ private:
 
     /** list of pictures references*/
     GList *lPictureReferences;
-
 
     /** The item id for each toc items */
     int idItemToc;

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -679,7 +679,7 @@ public:
     GBool isUnderlined() { return underlined; }
     GString *getLinkURI();
 
-    void setLineNumber(GBool theBool);
+    void setLineNumber(bool theBool);
 
 private:
     TextWord(TextWord *word);
@@ -694,7 +694,7 @@ private:
 
     GBool invisible;		// set for invisible text (render mode 3)
 
-    GBool lineNumber = gFalse;
+    bool lineNumber = false;
 
     friend class TextBlock;
     friend class TextLine;
@@ -758,10 +758,14 @@ public:
 
     Unicode getChar(int idx);
 
+    void setLineNumber(bool theBool);
+
 //private:
     /** Rank in the original flow */
     int indexmin;
     int indexmax;
+
+    bool lineNumber = false;
 
     friend class TextPage;
 };
@@ -986,7 +990,7 @@ public:
     /** Dump contents of the current page
      * @param blocks To know if the blocks option is selected
      * @param fullFontName To know if the fullFontName option is selected */
-    void dump(GBool blocks, GBool fullFontName);
+    void dump(GBool blocks, GBool fullFontName, vector<bool> lineNumberStatus);
 
     /** Dump contents of the current page following the reading order.
      * @param blocks To know if the blocks option is selected
@@ -1148,13 +1152,13 @@ public:
     void restoreState(GfxState *state);
 
     /** Identify line numbers and mark corresponding raw word */
-    void markLineNumber();
+    bool markLineNumber();
 
     /** Set if the page contains a column of line numbers*/
-    void setLineNumber(GBool theBool);
+    void setLineNumber(bool theBool);
 
     /** get the presence of a column of line numbers in the text page */
-    GBool getLineNumber();
+    bool getLineNumber();
 
 //  void addLink(int xMin, int yMin, int xMax, int yMax, Link *link);
 
@@ -1165,7 +1169,7 @@ public:
                                 int* /* maskColors */, GBool inlineImg, GBool mask,int imageIndex);
 
     // utility function to save raw data to a png file using the ong lib
-    bool save_png (GString* file_name,
+    bool save_png(GString* file_name,
                    unsigned int width, unsigned int height, unsigned int row_stride,
                    unsigned char* data,
                    unsigned char bpp = 24, unsigned char color_type = PNG_COLOR_TYPE_RGB,
@@ -1222,8 +1226,7 @@ public:
     GList *blocks;
 
     // clamp to uint8
-    static inline int clamp (int x)
-    {
+    static inline int clamp (int x) {
         if (x > 255) return 255;
         if (x < 0) return 0;
         return x;
@@ -1326,6 +1329,7 @@ private:
 
     /** The XML document for page */
     xmlDocPtr docPage;
+
     /** The page element */
     xmlNodePtr page;
 
@@ -1337,6 +1341,7 @@ private:
 
     /** The XML document for vectorials instructions */
     xmlDocPtr vecdoc;
+
     /** The vectorials intructions element */
     xmlNodePtr vecroot;
 
@@ -1353,49 +1358,66 @@ private:
 
     /** PL: To modify the blocks in reading order */
     GBool readingOrder;
+
     /** To know if the verbose option is selected */
     GBool verbose;
+
     /** To know if the cutPages option is selected */
     GBool cutter;
 
     /** The width of current page */
     double pageWidth;
+
     /** The height of current page */
     double pageHeight;
+
     /** The currently active string */
     TextRawWord *curWord;
+
     /** The next character position (within content stream) */
     int charPos;
+
     /** The current font */
     TextFontInfo *curFont;
 
     int curRot;			// current rotation
     GBool diagonal;		// set if rotation is not close to
+
     //   0/90/180/270 degrees
     /** The current font size */
     double curFontSize;
+
     /** The current nesting level (for Type 3 fonts) */
     int nest;
+
     /** The number of "tiny" chars seen so far */
     int nTinyChars;
+
     /** To set if the last added char overlapped the previous char */
     GBool lastCharOverlap;
 
     /** The primary rotation */
     int primaryRot;
+
     /** The primary direction (<code>true</code> means L-to-R, <code>false</code> means R-to-L) */
     GBool primaryLR;
     GList *chars;			// [TextChar]
+
     /** The list of words */
     GList *words;
+
     /** The list of words, in raw order (only if rawOrder is set) */
     //TextRawWord *rawWords;
+
     /** The last word on rawWords list */
     //TextRawWord *rawLastWord;
+
     /** All fonts info objects used on this page <code>TextFontInfo</code> */
     GList *fonts;
+
     /** The <b>x</b> value coordinate of the last "find" result */
     double lastFindXMin;
+
     /** The <b>y</b> value coordinate of the last "find" result */
     double lastFindYMin;
     GBool haveLastFind;
@@ -1415,7 +1437,6 @@ private:
     vector<Dict*>highlightedObject;
     Links *pageLinks;
 
-
     Unicode *actualText;		// current "ActualText" span
     int actualTextLen;
     double actualTextX0,
@@ -1424,7 +1445,6 @@ private:
             actualTextY1;
     int actualTextNBytes;
 
-
     GList *getChars(GList *charsA, double xMin, double yMin, double xMax, double yMax);
 
     ModifierClass classifyChar(Unicode u);
@@ -1432,7 +1452,7 @@ private:
     Unicode getCombiningDiacritic(ModifierClass modifierClass);
 
     /** if the page contains a column of line numbers */
-    GBool lineNumber = gFalse;
+    bool lineNumber = false;
 
 //    friend class TextBlock;
 //    friend class TextColumn;
@@ -1444,8 +1464,8 @@ private:
 // Simple class to save picture references
 class PictureReference
 {
-public:
 
+public:
     PictureReference (int ref, int flip, int number, const char* const extension) :
             reference_number(ref),
             picture_flip(flip),
@@ -1712,6 +1732,10 @@ public:
                                      double m21, double m22,
                                      double m31, double m32);
 
+    /** to keep track at document level of identified line numbers in each page */
+    vector<bool> getLineNumberStatus();
+    void appendLineNumberStatus(bool hasLineNumber);
+
 private:
     /** Generate the path
      * @param path The current path
@@ -1810,6 +1834,9 @@ private:
     SplashPath *convertPath(GfxState *state, GfxPath *path, GBool dropEmptySubpaths);
 
     bool isUTF8(Unicode *u, int uLen);
+
+    /** give for each page if line numbers have been found */
+    vector<bool> lineNumberStatus;
 };
 
 #endif

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -1777,6 +1777,10 @@ private:
     GBool readingOrder;
     /** To know if the blocks option is selected */
     GBool useBlocks;
+
+    /** To know if line numbers must be displayed or not */
+    GBool noLineNumbers;
+
     /** To know if the fullFontName option is selected */
     GBool fullFontName;
     /** To know if the noImageInline option is selected */

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -702,6 +702,8 @@ public:
     GBool isUnderlined() { return underlined; }
     GString *getLinkURI();
 
+    void setLineNumber(GBool theBool);
+
 private:
 
     TextWord(TextWord *word);
@@ -715,6 +717,8 @@ private:
     //TextLink *link;
 
     GBool invisible;		// set for invisible text (render mode 3)
+
+    GBool lineNumber = gFalse;;
 
     friend class TextBlock;
     friend class TextLine;
@@ -785,12 +789,16 @@ public:
 
     Unicode getChar(int idx);
 
+    // if the word token is a line number
+    void setLineNumber(GBool theBool);
 
 //private:
 
     /** Rank in the original flow */
     int indexmin;
     int indexmax;
+
+    GBool lineNumber;
 
     friend class TextPage;
 };
@@ -1190,6 +1198,8 @@ public:
      * @param state The state description */
     void restoreState(GfxState *state);
 
+    /** Identify line numbers and mark corresponding raw word */
+    void markLineNumber();
 
 //  void addLink(int xMin, int yMin, int xMax, int yMax, Link *link);
 

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -990,7 +990,7 @@ public:
     /** Dump contents of the current page
      * @param blocks To know if the blocks option is selected
      * @param fullFontName To know if the fullFontName option is selected */
-    void dump(GBool blocks, GBool fullFontName, vector<bool> lineNumberStatus);
+    void dump(GBool noLineNumbers, GBool fullFontName, vector<bool> lineNumberStatus);
 
     /** Dump contents of the current page following the reading order.
      * @param blocks To know if the blocks option is selected
@@ -1776,7 +1776,7 @@ private:
     /** To make text in reading order */
     GBool readingOrder;
     /** To know if the blocks option is selected */
-    GBool useBlocks;
+    //GBool useBlocks;
 
     /** To know if line numbers must be displayed or not */
     GBool noLineNumbers;

--- a/src/pdfalto.cc
+++ b/src/pdfalto.cc
@@ -207,13 +207,6 @@ int main(int argc, char *argv[]) {
         parameters->setCutAllPages(gTrue);
     }
 
-    /*if (blocks) {
-        parameters->setDisplayBlocks(gTrue);
-        cmd->append("-blocks ");
-    } else {
-        parameters->setDisplayBlocks(gFalse);
-    }*/
-
     if (noLineNumbers) {
         parameters->setNoLineNumbers(gTrue);
         cmd->append("-noLineNumbers ");
@@ -286,11 +279,6 @@ int main(int argc, char *argv[]) {
     } else {
         nsURI = NULL;
     }
-
-    //store paramneters in a given XML file
-    /*if (XMLcfgFileName[0]) {
-        parameters->saveToXML(XMLcfgFileName, firstPage, lastPage);
-    }*/
 
     if (argc < 2) { goto err0; }
     fileName = new GString(argv[1]);
@@ -379,7 +367,6 @@ int main(int argc, char *argv[]) {
     xmlAltoOut->addMetadataInfo(doc);
     xmlAltoOut->closeMetadataInfoDoc(shortFileName);
 
-
     if (xmlAltoOut->isOk()) {
 
         // We clean the data directory if it is already exist
@@ -438,6 +425,7 @@ int main(int argc, char *argv[]) {
     // check for memory leaks
     Object::memCheck(stderr);
     gMemReport(stderr);
+    
     return exitCode;
 }
 

--- a/src/pdfalto.cc
+++ b/src/pdfalto.cc
@@ -60,7 +60,8 @@ static GBool noText = gFalse;
 static GBool noImage = gFalse;
 static GBool outline = gFalse;
 static GBool cutPages = gFalse;
-static GBool blocks = gFalse;
+//static GBool blocks = gFalse;
+static GBool noLineNumbers = gFalse;
 static GBool fullFontName = gFalse;
 static GBool noImageInline = gFalse;
 static GBool annots = gFalse;
@@ -82,8 +83,6 @@ static ArgDesc argDesc[] = {
                 "last page to convert"},
         {"-verbose",       argFlag,   &verbose,         0,
                 "display pdf attributes"},
-        {"-noText",        argFlag,   &noText,          0,
-                "do not extract textual objects"},
         {"-noImage",       argFlag,   &noImage,         0,
                 "do not extract Images (Bitmap and Vectorial)"},
         {"-noImageInline", argFlag,   &noImageInline,   0,
@@ -95,12 +94,16 @@ static ArgDesc argDesc[] = {
 // PL: code for supporting cut pages need to be put back
 //        {"-cutPages",      argFlag,   &cutPages,        0,
 //                "cut all pages in separately files"},
-        {"-blocks",        argFlag,   &blocks,          0,
-                "add blocks informations within the structure"},
+//        {"-blocks",        argFlag,   &blocks,          0,
+//                "add blocks informations within the structure"},
+        {"-noLineNumbers",        argFlag,   &noLineNumbers,          0,
+                "do not output line numbers added in manuscript-style textual documents"},
         {"-readingOrder",  argFlag,   &readingOrder,    0,
                 "blocks follow the reading order"},
+        {"-noText",        argFlag,   &noText,          0,
+                "do not extract textual objects (might be useful, but non-valid ALTO)"},
         {"-charReadingOrderAttr",  argFlag,   &charReadingOrderAttr,    0,
-                "include TYPE attribute to String elements to indicate right-to-left reading order (not valid ALTO)"},
+                "include TYPE attribute to String elements to indicate right-to-left reading order (might be useful, but non-valid ALTO)"},
 //        {"-ocr",           argFlag,   &ocr,             0,
 //                "recognises all characters that are missing from unicode."},
         {"-fullFontName",  argFlag,   &fullFontName,    0,
@@ -111,6 +114,8 @@ static ArgDesc argDesc[] = {
                 "owner password (for encrypted files)"},
         {"-upw",           argString, userPassword,     sizeof(userPassword),
                 "user password (for encrypted files)"},
+        {"-filesLimit",    argInt,    &filesCountLimit, 0,
+                "limit of asset files be extracted"},
         {"-q",             argFlag,   &quiet,           0,
                 "don't print any messages or errors"},
         {"-v",             argFlag,   &printVersion,    0,
@@ -123,13 +128,10 @@ static ArgDesc argDesc[] = {
                 "print usage information"},
         {"-?",             argFlag,   &printHelp,       0,
                 "print usage information"},
-        {"--saveconf",     argString, XMLcfgFileName,   sizeof(XMLcfgFileName),
-                "save all command line parameters in the specified XML <file>"},
-        {"-conf",          argString, cfgFileName,      sizeof(cfgFileName),
-                "configuration file to use in place of xpdfrc"},
-
-        {"-filesLimit",    argInt,    &filesCountLimit, 0,
-                "limit of asset files be extracted"},
+//        {"--saveconf",     argString, XMLcfgFileName,   sizeof(XMLcfgFileName),
+//                "save all command line parameters in the specified XML <file>"},
+//        {"-conf",          argString, cfgFileName,      sizeof(cfgFileName),
+//                "configuration file to use in place of xpdfrc"},
         {NULL}
 };
 
@@ -164,7 +166,6 @@ int main(int argc, char *argv[]) {
             fprintf(stderr, " version ");
             fprintf(stderr, "%s", PDFALTO_VERSION);
             fprintf(stderr, "\n");
-            //fprintf(stderr, "(Based on Xpdf version %s, %s)\n", xpdfVersion, xpdfCopyright);
             if (!printVersion) {
                 printUsage("pdfalto", "<PDF-file> [<xml-file>]", argDesc);
             }
@@ -206,11 +207,18 @@ int main(int argc, char *argv[]) {
         parameters->setCutAllPages(gTrue);
     }
 
-    if (blocks) {
+    /*if (blocks) {
         parameters->setDisplayBlocks(gTrue);
         cmd->append("-blocks ");
     } else {
         parameters->setDisplayBlocks(gFalse);
+    }*/
+
+    if (noLineNumbers) {
+        parameters->setNoLineNumbers(gTrue);
+        cmd->append("-noLineNumbers ");
+    } else {
+        parameters->setNoLineNumbers(gFalse);
     }
 
     if (readingOrder) {
@@ -280,10 +288,9 @@ int main(int argc, char *argv[]) {
     }
 
     //store paramneters in a given XML file
-    if (XMLcfgFileName[0]) {
+    /*if (XMLcfgFileName[0]) {
         parameters->saveToXML(XMLcfgFileName, firstPage, lastPage);
-//   	goto err0;
-    }
+    }*/
 
     if (argc < 2) { goto err0; }
     fileName = new GString(argv[1]);
@@ -314,7 +321,7 @@ int main(int argc, char *argv[]) {
             shortFileName = new GString(textFileName);
         }
     }
-        // ELSE we build the output XML file name with the PDF file name
+    // ELSE we build the output XML file name with the PDF file name
     else {
         p = fileName->getCString() + fileName->getLength() - 4;
         if (!strcmp(p, EXTENSION_PDF) || !strcmp(p, EXTENSION_PDF_MAJ)) {


### PR DESCRIPTION
This PR adds the identification of vertical line numbers as present in some manuscripts and pre-print. Instead of having these line numbers mixed with the text content in several blocks, they are all present in one block corresponding to an independent column, thus avoiding bad text mixture.

It is possible to ignore the line number now with the parameter `-noLineNumbers`, the corresponding block is simply not serialized. 

The parameters here have been reviewed following #70, removing useless `-blocks` (we always output blocks because it is necessary for valid ALTO). We keep `-noText` because some persons are using it, but this is also not ALTO valid. 

After updating xpdf to 4.02 (or 4.01.01, see #46), this should finalize version 0.3 of pdfalto and we would then move to v 0.4.