### PR TITLE
added libs directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ Makefile
 *.cbp
 .DS_Store
 ./*.xml_data/
-libs/image/png/src/libpng.a
-libs/image/zlib/src/libzlib.a
+libs
 traingenerator
 jeu/*


### PR DESCRIPTION
I am not sure whether you agree with it...
But after running `install_deps.sh` I ended up with a lot of changes.
Shouldn't the whole `libs` folder be excluded? (some files are currently committed to the repo)