### PR TITLE
Update .gitmodules to use https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "xpdf-4.03"]
 	path = xpdf-4.03
-	url = git@github.com:kermitt2/xpdf-4.03.git
+	url = https://github.com/kermitt2/xpdf-4.03.git


### PR DESCRIPTION
Changed xpdf repository URL from ssh to https to [avoid (unnecessary) public key validation which causes issues e.g. in docker containers](https://stackoverflow.com/a/16465182/5743296).