### PR TITLE
Fix  #144

### DIFF
--- a/src/pdfalto.cc
+++ b/src/pdfalto.cc
@@ -187,7 +187,7 @@ int main(int argc, char *argv[]) {
 
     char *dirname;
     dirname = (char*)malloc(dirname_length + 1);
-    strncat(dirname, thePath, dirname_length); 
+    strncpy(dirname, thePath, dirname_length); 
     dirname[dirname_length] = '\0';
 
     // set the config file path as alongside the executable


### PR DESCRIPTION
malloc() call doesn't zero-ed allocated memory, resulting in appending `thePath` to some garbage in strncat(). It's better to use strncpy()