### PR TITLE
Add libfontconfig-dev to install_deps.sh

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -36,7 +36,7 @@ echo ${OSTYPE}
 
 if [[ "${OSTYPE}" == "linux"* ]]; then
   if ! [ -x "$(command -v autoreconf)" ]; then
-    sudo apt-get install autoconf
+    sudo apt-get install autoconf libfontconfig-dev
   fi
   ICU_CONFIG="Linux"
   LIB_INSTALL="linux"
@@ -60,7 +60,7 @@ elif [[ "$OSTYPE" == "cygwin" ]]; then
 else
   echo "Unknown OSTYPE: $OSTYPE, assuming it's LINUX"
   if ! [ -x "$(command -v autoreconf)" ]; then
-    sudo apt-get install autoconf
+    sudo apt-get install autoconf libfontconfig-dev
   fi
   ICU_CONFIG="Linux"
   LIB_INSTALL="linux"


### PR DESCRIPTION
I had to install `libfontconfig-dev` on my system for a successful build.