### PR TITLE
Update ci-build-libs.yml -  update to libpng-1.6.47

### DIFF
--- a/.github/workflows/ci-build-libs.yml
+++ b/.github/workflows/ci-build-libs.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Download source
         run: |
           cd libs/image/png
-          wget -O source.tar.gz https://sourceforge.net/projects/libpng/files/libpng16/1.6.46/libpng-1.6.46.tar.gz/download
+          wget -O source.tar.gz https://sourceforge.net/projects/libpng/files/libpng16/1.6.47/libpng-1.6.47.tar.gz/download
           tar -zxf source.tar.gz
           mv libpng* src
 


### PR DESCRIPTION
Update due to vulnerability https://github.com/pnggroup/libpng/issues/656