### PR TITLE
Fix line number recognition

### DIFF
--- a/scripts/alto2text.sh
+++ b/scripts/alto2text.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+export PDFALTO_PATH=../
+export PDFALTO_XSLT=../schema/alto2txt.xsl
+
+# Function to process PDF files
+process_pdf_files() {
+  local input_dir="$1"
+  local output_dir="$2"
+
+  # Create the output directory if it doesn't exist
+  mkdir -p "$output_dir"
+
+  # Loop through all files and directories in the input directory
+  for entry in "$input_dir"/*; do
+    if [ -d "$entry" ]; then
+      # If the entry is a directory, recursively process it
+      local subdir_name=$(basename "$entry")
+      process_pdf_files "$entry" "$output_dir/$subdir_name"
+    elif [ -f "$entry" ] && [[ "$entry" == *.xml ]]; then
+      # If the entry is a XML file, transform it to text
+      echo "Processing $entry"
+      local filename=$(basename "$entry")
+      xsltproc ${PDFALTO_XSLT} "$entry" > "$output_dir/${filename%.xml}.txt"
+    fi
+  done
+}
+
+# Main script execution
+input_directory="$1"
+output_directory="$2"
+
+if [ -z "$input_directory" ] || [ -z "$output_directory" ]; then
+  echo "Usage: $0 <input_directory> <output_directory>"
+  exit 1
+fi
+
+process_pdf_files "$input_directory" "$output_directory"

--- a/scripts/compare_pdfalto.py
+++ b/scripts/compare_pdfalto.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""
+Compare multiple pdfalto versions on a directory of PDFs.
+
+This script runs multiple pdfalto executables on PDF files, converts the ALTO XML
+output to plain text, and compares the results using various metrics.
+"""
+
+import argparse
+import csv
+import html
+import subprocess
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+try:
+    from rapidfuzz.distance import Levenshtein
+    HAS_RAPIDFUZZ = True
+except ImportError:
+    HAS_RAPIDFUZZ = False
+    print("Warning: rapidfuzz not installed. Install it before contitnue.", file=sys.stderr)
+    sys.exit(-1)
+
+try:
+    from rouge_score import rouge_scorer
+    HAS_ROUGE = True
+except ImportError:
+    HAS_ROUGE = False
+
+try:
+    import sacrebleu
+    HAS_SACREBLEU = True
+except ImportError:
+    HAS_SACREBLEU = False
+
+
+
+def run_pdfalto(pdfalto_exe: Path, pdf_path: Path, output_xml: Path) -> bool:
+    """Run pdfalto on a PDF file."""
+    # Using the command pattern from pdfalto2text.sh
+    cmd = [
+        str(pdfalto_exe),
+        '-noImageInline',
+        '-fullFontName',
+        '-noImage',
+        '-readingOrder',
+        str(pdf_path),
+        str(output_xml)
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+        if result.returncode != 0:
+            return False
+        # Validate that output file exists and is non-empty
+        if not output_xml.exists() or output_xml.stat().st_size == 0:
+            print(f"Warning: pdfalto produced empty output for {pdf_path}", file=sys.stderr)
+            return False
+        return True
+    except subprocess.TimeoutExpired:
+        print(f"Timeout processing {pdf_path}", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"Error running pdfalto on {pdf_path}: {e}", file=sys.stderr)
+        return False
+
+
+def alto_to_text(xml_path: Path, xslt_path: Path, output_txt: Path) -> bool:
+    """Convert ALTO XML to plain text using xsltproc."""
+    cmd = ['xsltproc', str(xslt_path), str(xml_path)]
+    try:
+        result = subprocess.run(cmd, capture_output=True, encoding='utf-8', timeout=60)
+        if result.returncode == 0:
+            with open(output_txt, 'w', encoding='utf-8') as f:
+                f.write(result.stdout)
+            # Warn if output is empty (possibly namespace mismatch)
+            if not result.stdout.strip():
+                print(f"Warning: xsltproc produced empty output for {xml_path}", file=sys.stderr)
+            return True
+        print(f"Error: xsltproc failed for {xml_path}: {result.stderr}", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"Error converting {xml_path} to text: {e}", file=sys.stderr)
+        return False
+
+
+def process_single_pdf(
+    pdf_path: Path,
+    input_dir: Path,
+    output_dir: Path,
+    pdfalto_dirs: List[Path],
+    xslt_path: Path,
+    no_resume: bool = False
+) -> List[Tuple[str, Path, bool]]:
+    """Process a single PDF with all pdfalto versions. Returns list of (version_id, txt_path, success)."""
+    results = []
+
+    # Calculate relative path
+    rel_path = pdf_path.relative_to(input_dir)
+
+    for pdfalto_dir in pdfalto_dirs:
+        version_id = pdfalto_dir.name
+        pdfalto_exe = pdfalto_dir / 'pdfalto'
+
+        if not pdfalto_exe.exists():
+            print(f"Warning: pdfalto executable not found in {pdfalto_dir}", file=sys.stderr)
+            results.append((version_id, None, False))
+            continue
+
+        # Output paths
+        version_output_dir = output_dir / version_id / rel_path.parent
+        version_output_dir.mkdir(parents=True, exist_ok=True)
+
+        output_xml = version_output_dir / f"{pdf_path.stem}.xml"
+        output_txt = version_output_dir / f"{pdf_path.stem}.txt"
+
+        # Resume logic: skip if text file already exists (and is non-empty)
+        if not no_resume and output_txt.exists() and output_txt.stat().st_size > 0:
+            results.append((version_id, output_txt, True))
+            continue
+
+        # Run pdfalto
+        success = run_pdfalto(pdfalto_exe, pdf_path, output_xml)
+
+        if success and output_xml.exists():
+            # Convert to text
+            success = alto_to_text(output_xml, xslt_path, output_txt)
+
+        results.append((version_id, output_txt if success else None, success))
+
+    return results
+
+
+def find_pdfs(input_dir: Path) -> List[Path]:
+    """Find all PDF files in the input directory tree."""
+    return list(input_dir.rglob('*.pdf'))
+
+
+def read_text_file(filepath: Path) -> str:
+    """Read text content from a file."""
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            return f.read()
+    except Exception as e:
+        print(f"Error reading {filepath}: {e}", file=sys.stderr)
+        return ""
+
+
+def normalize_spaces(text: str) -> str:
+    """Normalize spaces in text (collapse whitespace)."""
+    return ''.join(text.split())
+
+
+def compute_edit_distance(text1: str, text2: str) -> float:
+    """Compute normalized edit distance between two texts."""
+    if not text1 and not text2:
+        return 0.0
+    if not text1 or not text2:
+        return 1.0
+
+    distance = Levenshtein.distance(text1, text2)
+
+    max_len = max(len(text1), len(text2))
+    return distance / max_len if max_len > 0 else 0.0
+
+
+def compute_rouge(text1: str, text2: str) -> Dict[str, float]:
+    """Compute ROUGE scores between two texts."""
+    if not HAS_ROUGE:
+        return {}
+
+    # Guard against empty texts which can cause issues with ROUGE
+    if not text1.strip() or not text2.strip():
+        return {
+            'rouge1_f': 0.0,
+            'rouge2_f': 0.0,
+            'rougeL_f': 0.0
+        }
+
+    scorer = rouge_scorer.RougeScorer(['rouge1', 'rouge2', 'rougeL'], use_stemmer=True)
+    scores = scorer.score(text1, text2)
+
+    return {
+        'rouge1_f': scores['rouge1'].fmeasure,
+        'rouge2_f': scores['rouge2'].fmeasure,
+        'rougeL_f': scores['rougeL'].fmeasure
+    }
+
+
+def compute_bleu(reference: str, hypothesis: str) -> float:
+    """Compute BLEU score."""
+    if not HAS_SACREBLEU:
+        return 0.0
+
+    try:
+        bleu = sacrebleu.sentence_bleu(hypothesis, [reference])
+        return bleu.score / 100.0  # Normalize to 0-1
+    except Exception:
+        return 0.0
+
+
+def compare_texts(
+    text1: str,
+    text2: str,
+    metrics: List[str]
+) -> Dict[str, float]:
+    """Compare two texts using specified metrics."""
+    results = {}
+
+    if 'edit_distance' in metrics:
+        results['edit_distance'] = compute_edit_distance(text1, text2)
+
+    if 'edit_distance_no_spaces' in metrics:
+        t1_normalized = normalize_spaces(text1)
+        t2_normalized = normalize_spaces(text2)
+        results['edit_distance_no_spaces'] = compute_edit_distance(t1_normalized, t2_normalized)
+
+    if 'rouge' in metrics and HAS_ROUGE:
+        rouge_scores = compute_rouge(text1, text2)
+        results.update(rouge_scores)
+
+    if 'bleu' in metrics and HAS_SACREBLEU:
+        results['bleu'] = compute_bleu(text1, text2)
+
+    return results
+
+
+def generate_comparison_report(
+    output_dir: Path,
+    pdfalto_dirs: List[Path],
+    input_dir: Path,
+    metrics: List[str]
+) -> Path:
+    """Generate comparison CSV report."""
+    report_path = output_dir / 'comparison_results.csv'
+
+    version_ids = [d.name for d in pdfalto_dirs]
+
+    # Find all processed text files
+    all_txt_files = {}
+    for version_id in version_ids:
+        version_dir = output_dir / version_id
+        if version_dir.exists():
+            for txt_file in version_dir.rglob('*.txt'):
+                rel_path = txt_file.relative_to(version_dir)
+                if rel_path not in all_txt_files:
+                    all_txt_files[rel_path] = {}
+                all_txt_files[rel_path][version_id] = txt_file
+
+    # Prepare CSV columns
+    metric_columns = []
+    if 'edit_distance' in metrics:
+        metric_columns.append('edit_distance')
+    if 'edit_distance_no_spaces' in metrics:
+        metric_columns.append('edit_distance_no_spaces')
+    if 'rouge' in metrics and HAS_ROUGE:
+        metric_columns.extend(['rouge1_f', 'rouge2_f', 'rougeL_f'])
+    if 'bleu' in metrics and HAS_SACREBLEU:
+        metric_columns.append('bleu')
+
+    # Generate pairwise comparisons
+    rows = []
+    partial_failures = []  # Track PDFs missing some versions
+
+    for rel_path, versions in sorted(all_txt_files.items()):
+        version_list = list(versions.keys())
+
+        # Warn about partial failures (PDF processed by some versions but not all)
+        missing_versions = set(version_ids) - set(version_list)
+        if missing_versions and len(version_list) > 0:
+            partial_failures.append((rel_path, missing_versions))
+
+        for i, v1 in enumerate(version_list):
+            for v2 in version_list[i+1:]:
+                text1 = read_text_file(versions[v1])
+                text2 = read_text_file(versions[v2])
+
+                comparison = compare_texts(text1, text2, metrics)
+
+                row = {
+                    'pdf_path': str(rel_path).replace('.txt', '.pdf'),
+                    'version_a': v1,
+                    'version_b': v2
+                }
+                row.update(comparison)
+                rows.append(row)
+
+    # Report partial failures
+    if partial_failures:
+        print(f"\nWarning: {len(partial_failures)} PDF(s) had partial processing failures:", file=sys.stderr)
+        for rel_path, missing in partial_failures[:10]:  # Show first 10
+            print(f"  {rel_path}: missing {', '.join(sorted(missing))}", file=sys.stderr)
+        if len(partial_failures) > 10:
+            print(f"  ... and {len(partial_failures) - 10} more", file=sys.stderr)
+
+    # Write CSV
+    if rows:
+        fieldnames = ['pdf_path', 'version_a', 'version_b'] + metric_columns
+        with open(report_path, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow({k: row.get(k, '') for k in fieldnames})
+
+        # Print summary to console
+        print(f"\n{'='*60}")
+        print(f"SUMMARY BY SUBFOLDER")
+        print(f"{'='*60}")
+
+        # Group results by subfolder
+        from collections import defaultdict
+        subfolder_results = defaultdict(list)
+        for row in rows:
+            pdf_path = Path(row['pdf_path'])
+            subfolder = str(pdf_path.parent) if pdf_path.parent != Path('.') else '(root)'
+            subfolder_results[subfolder].append(row)
+
+        # Print per-subfolder averages
+        for subfolder in sorted(subfolder_results.keys()):
+            subfolder_rows = subfolder_results[subfolder]
+            print(f"\n{subfolder}/ ({len(subfolder_rows)} comparisons)")
+            for metric in metric_columns:
+                values = [r.get(metric, 0) for r in subfolder_rows if r.get(metric) is not None]
+                if values:
+                    avg = sum(values) / len(values)
+                    print(f"  {metric}: {avg:.4f}")
+
+        print(f"\n{'='*60}")
+        print(f"OVERALL SUMMARY")
+        print(f"{'='*60}")
+        print(f"Total comparisons: {len(rows)}")
+
+        # Calculate and print averages for each metric
+        if metric_columns:
+            print(f"\nAverage metrics across all comparisons:")
+            for metric in metric_columns:
+                values = [row.get(metric, 0) for row in rows if row.get(metric) is not None]
+                if values:
+                    avg = sum(values) / len(values)
+                    print(f"  {metric}: {avg:.4f}")
+
+        # Print detailed results
+        print(f"\n{'='*60}")
+        print(f"DETAILED RESULTS")
+        print(f"{'='*60}")
+        for row in rows:
+            print(f"\n{row['pdf_path']}")
+            print(f"  {row['version_a']} vs {row['version_b']}:")
+            for metric in metric_columns:
+                if metric in row:
+                    print(f"    {metric}: {row[metric]:.4f}")
+    else:
+        print("\nNo comparisons were generated. Check that:")
+        print("  - PDF files were successfully processed")
+        print("  - Text files were generated for at least 2 versions")
+
+    return report_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Compare multiple pdfalto versions on PDF files.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --input-dir ./pdfs --output-dir ./results --pdfalto-dirs ./pdfalto-v1 ./pdfalto-v2
+  %(prog)s --input-dir ./pdfs --output-dir ./results --pdfalto-dirs ./pdfalto-* --n-workers 4
+  %(prog)s --input-dir ./pdfs --output-dir ./results --pdfalto-dirs ./builds/* --metrics edit_distance,rouge
+"""
+    )
+
+    parser.add_argument(
+        '--input-dir', '-i',
+        type=Path,
+        required=True,
+        help='Directory containing PDF files (recursive)'
+    )
+
+    parser.add_argument(
+        '--output-dir', '-o',
+        type=Path,
+        required=True,
+        help='Output directory for results'
+    )
+
+    parser.add_argument(
+        '--pdfalto-dirs', '-p',
+        type=Path,
+        nargs='+',
+        required=True,
+        help='Directories containing pdfalto executables (format: pdfalto-{REV}/pdfalto)'
+    )
+
+    parser.add_argument(
+        '--xslt-path',
+        type=Path,
+        default=None,
+        help='Path to alto2txt.xsl (default: ../schema/alto2txt.xsl relative to script)'
+    )
+
+    parser.add_argument(
+        '--metrics', '-m',
+        type=str,
+        default='edit_distance,edit_distance_no_spaces',
+        help='Comma-separated metrics: edit_distance,edit_distance_no_spaces,rouge,bleu'
+    )
+
+    parser.add_argument(
+        '--n-workers', '-w',
+        type=int,
+        default=1,
+        help='Number of parallel workers (default: 1)'
+    )
+
+    parser.add_argument(
+        '--no-resume',
+        action='store_true',
+        help='Disable resume (reprocess all PDFs)'
+    )
+
+    args = parser.parse_args()
+
+    # Validate input directory
+    if not args.input_dir.exists():
+        print(f"Error: Input directory does not exist: {args.input_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Set default XSLT path
+    if args.xslt_path is None:
+        script_dir = Path(__file__).parent.resolve()
+        args.xslt_path = (script_dir / '..' / 'schema' / 'alto2txt.xsl').resolve()
+
+    # Resolve to absolute path
+    args.xslt_path = args.xslt_path.resolve()
+
+    if not args.xslt_path.exists():
+        print(f"Error: XSLT file not found: {args.xslt_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.xslt_path.is_file():
+        print(f"Error: XSLT path is not a file: {args.xslt_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Validate pdfalto directories
+    valid_pdfalto_dirs = []
+    for pdfalto_dir in args.pdfalto_dirs:
+        if pdfalto_dir.exists():
+            valid_pdfalto_dirs.append(pdfalto_dir)
+        else:
+            print(f"Warning: pdfalto directory not found: {pdfalto_dir}", file=sys.stderr)
+
+    if len(valid_pdfalto_dirs) < 2:
+        print("Error: At least 2 valid pdfalto directories are required for comparison", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse metrics
+    metrics = [m.strip() for m in args.metrics.split(',')]
+
+    # Check metric dependencies
+    if 'rouge' in metrics and not HAS_ROUGE:
+        print("Warning: rouge-score not installed. ROUGE metrics will be skipped.", file=sys.stderr)
+    if 'bleu' in metrics and not HAS_SACREBLEU:
+        print("Warning: sacrebleu not installed. BLEU metric will be skipped.", file=sys.stderr)
+
+    # Create output directory
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Find PDFs
+    pdfs = find_pdfs(args.input_dir)
+    print(f"Found {len(pdfs)} PDF files to process")
+    print(f"Using {len(valid_pdfalto_dirs)} pdfalto versions: {[d.name for d in valid_pdfalto_dirs]}")
+    print(f"Metrics: {metrics}")
+    print(f"Workers: {args.n_workers}")
+    print(f"XSLT: {args.xslt_path}")
+    if not args.no_resume:
+        print("Resume enabled: skipping PDFs with existing text output")
+
+    # Process PDFs
+    if args.n_workers == 1:
+        # Sequential processing
+        for i, pdf_path in enumerate(pdfs, 1):
+            rel_path = pdf_path.relative_to(args.input_dir)
+            print(f"[{i}/{len(pdfs)}] Processing {rel_path}...")
+            process_single_pdf(
+                pdf_path,
+                args.input_dir,
+                args.output_dir,
+                valid_pdfalto_dirs,
+                args.xslt_path,
+                args.no_resume
+            )
+    else:
+        # Parallel processing
+        with ProcessPoolExecutor(max_workers=args.n_workers) as executor:
+            futures = {
+                executor.submit(
+                    process_single_pdf,
+                    pdf_path,
+                    args.input_dir,
+                    args.output_dir,
+                    valid_pdfalto_dirs,
+                    args.xslt_path,
+                    args.no_resume
+                ): pdf_path
+                for pdf_path in pdfs
+            }
+
+            for i, future in enumerate(as_completed(futures), 1):
+                pdf_path = futures[future]
+                rel_path = pdf_path.relative_to(args.input_dir)
+                try:
+                    future.result()
+                    print(f"[{i}/{len(pdfs)}] Completed {rel_path}")
+                except Exception as e:
+                    print(f"[{i}/{len(pdfs)}] Error processing {rel_path}: {e}", file=sys.stderr)
+
+    # Generate comparison report
+    print("\nGenerating comparison report...")
+    report_path = generate_comparison_report(
+        args.output_dir,
+        valid_pdfalto_dirs,
+        args.input_dir,
+        metrics
+    )
+    print(f"Comparison report saved to: {report_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/compare_revisions.py
+++ b/scripts/compare_revisions.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""
+Compare pdfalto output between a git revision and the current working tree.
+
+Builds both versions automatically using git worktrees, runs them on the
+given PDF files, and reports structural differences in the ALTO XML output
+(blocks, line numbers, text content).
+
+Usage:
+    ./scripts/compare_revisions.py <revision> <pdf> [<pdf> ...]
+    ./scripts/compare_revisions.py HEAD~1 /path/to/paper.pdf
+    ./scripts/compare_revisions.py v0.5.0 /path/to/*.pdf
+
+Requirements: cmake, a C++ compiler, and the project's build dependencies.
+"""
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ALTO_NS = {"alto": "http://www.loc.gov/standards/alto/ns-v3#"}
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Build helpers
+# ---------------------------------------------------------------------------
+
+def resolve_revision(revision: str) -> str:
+    """Resolve a revision spec to a full commit hash."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", revision],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    if result.returncode != 0:
+        sys.exit(f"Error: cannot resolve revision '{revision}': {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def revision_label(revision: str) -> str:
+    """Short human-readable label for a commit."""
+    result = subprocess.run(
+        ["git", "log", "--format=%h %s", "-1", revision],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    return result.stdout.strip() if result.returncode == 0 else revision[:10]
+
+
+def build_in_worktree(revision: str, tmpdir: Path) -> Path:
+    """Create a git worktree at *revision*, build pdfalto, return the binary path."""
+    worktree = tmpdir / f"worktree-{revision[:10]}"
+    print(f"  Creating worktree at {worktree} ...")
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(worktree), revision],
+        capture_output=True, text=True, cwd=REPO_ROOT, check=True,
+    )
+
+    # Initialize submodules in the worktree
+    print(f"  Initializing submodules ...")
+    subprocess.run(
+        ["git", "submodule", "update", "--init", "--recursive"],
+        capture_output=True, text=True, cwd=worktree,
+    )
+
+    # Pre-build xpdf dependency (generates aconf.h which is gitignored)
+    xpdf_build = worktree / "xpdf-4.05" / "build"
+    if not (xpdf_build / "aconf.h").exists():
+        xpdf_build.mkdir(parents=True, exist_ok=True)
+        print(f"  Pre-configuring xpdf (generating aconf.h) ...")
+        subprocess.run(
+            ["cmake", ".."],
+            capture_output=True, text=True, cwd=xpdf_build,
+        )
+
+    build_dir = worktree / "build"
+    build_dir.mkdir()
+
+    print(f"  Configuring ...")
+    r = subprocess.run(
+        ["cmake", ".."],
+        capture_output=True, text=True, cwd=build_dir,
+    )
+    if r.returncode != 0:
+        sys.exit(f"cmake configure failed:\n{r.stderr}")
+
+    print(f"  Building ...")
+    r = subprocess.run(
+        ["cmake", "--build", ".", "--parallel"],
+        capture_output=True, text=True, cwd=build_dir,
+    )
+    if r.returncode != 0:
+        sys.exit(f"cmake build failed:\n{r.stderr}")
+
+    binary = build_dir / "pdfalto"
+    if not binary.exists():
+        sys.exit(f"Build succeeded but binary not found at {binary}")
+    return binary
+
+
+def build_current(tmpdir: Path) -> Path:
+    """Build the current working tree, return the binary path."""
+    build_dir = REPO_ROOT / "cmake-build-compare"
+    build_dir.mkdir(exist_ok=True)
+
+    print(f"  Configuring ...")
+    r = subprocess.run(
+        ["cmake", ".."],
+        capture_output=True, text=True, cwd=build_dir,
+    )
+    if r.returncode != 0:
+        sys.exit(f"cmake configure failed:\n{r.stderr}")
+
+    print(f"  Building ...")
+    r = subprocess.run(
+        ["cmake", "--build", ".", "--parallel"],
+        capture_output=True, text=True, cwd=build_dir,
+    )
+    if r.returncode != 0:
+        sys.exit(f"cmake build failed:\n{r.stderr}")
+
+    binary = build_dir / "pdfalto"
+    if not binary.exists():
+        sys.exit(f"Build succeeded but binary not found at {binary}")
+    return binary
+
+
+def cleanup_worktree(revision: str, tmpdir: Path):
+    worktree = tmpdir / f"worktree-{revision[:10]}"
+    if worktree.exists():
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(worktree)],
+            capture_output=True, text=True, cwd=REPO_ROOT,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Run pdfalto
+# ---------------------------------------------------------------------------
+
+def run_pdfalto(binary: Path, pdf: Path, output_xml: Path) -> bool:
+    r = subprocess.run(
+        [str(binary), str(pdf), str(output_xml)],
+        capture_output=True, text=True, timeout=300,
+    )
+    return r.returncode == 0 and output_xml.exists()
+
+
+# ---------------------------------------------------------------------------
+# ALTO XML analysis
+# ---------------------------------------------------------------------------
+
+class PageStats:
+    def __init__(self):
+        self.total_blocks = 0
+        self.total_lines = 0
+        self.dedicated_line_nums = 0   # in a multi-number block (>10)
+        self.single_number_blocks = 0  # standalone single-digit blocks
+        self.content_blocks = 0
+        self.first_content = ""        # first few words of content
+
+    def __repr__(self):
+        parts = [f"blocks={self.total_blocks}"]
+        if self.dedicated_line_nums:
+            parts.append(f"lineNums={self.dedicated_line_nums}")
+        if self.single_number_blocks:
+            parts.append(f"singles={self.single_number_blocks}")
+        return ", ".join(parts)
+
+
+def analyze_page(page_elem) -> PageStats:
+    stats = PageStats()
+    first_content_found = False
+
+    for block in page_elem.findall(".//alto:TextBlock", ALTO_NS):
+        stats.total_blocks += 1
+        lines = block.findall(".//alto:TextLine", ALTO_NS)
+        stats.total_lines += len(lines)
+
+        # Count number-only lines in this block
+        num_only = 0
+        for line in lines:
+            tokens = line.findall(".//alto:String", ALTO_NS)
+            if len(tokens) == 1 and tokens[0].get("CONTENT", "").isdigit():
+                num_only += 1
+
+        if num_only > 10:
+            stats.dedicated_line_nums += num_only
+        elif num_only == 1 and len(lines) == 1:
+            stats.single_number_blocks += 1
+        else:
+            stats.content_blocks += 1
+            if not first_content_found and lines:
+                tokens = lines[0].findall(".//alto:String", ALTO_NS)
+                stats.first_content = " ".join(
+                    t.get("CONTENT", "") for t in tokens[:8]
+                )
+                first_content_found = True
+
+    return stats
+
+
+def analyze_alto(xml_path: Path) -> list[PageStats]:
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    return [analyze_page(p) for p in root.findall(".//alto:Page", ALTO_NS)]
+
+
+# ---------------------------------------------------------------------------
+# Comparison and reporting
+# ---------------------------------------------------------------------------
+
+def compare_and_report(pdf_name: str, old_stats: list[PageStats], new_stats: list[PageStats],
+                       old_label: str, new_label: str):
+    n_pages = max(len(old_stats), len(new_stats))
+
+    has_diff = False
+    diff_rows = []
+    for i in range(n_pages):
+        old = old_stats[i] if i < len(old_stats) else PageStats()
+        new = new_stats[i] if i < len(new_stats) else PageStats()
+
+        diffs = []
+        if old.total_blocks != new.total_blocks:
+            diffs.append(f"blocks {old.total_blocks}->{new.total_blocks}")
+        if old.dedicated_line_nums != new.dedicated_line_nums:
+            diffs.append(f"lineNums {old.dedicated_line_nums}->{new.dedicated_line_nums}")
+        if old.single_number_blocks != new.single_number_blocks:
+            diffs.append(f"singles {old.single_number_blocks}->{new.single_number_blocks}")
+        if old.total_lines != new.total_lines:
+            diffs.append(f"lines {old.total_lines}->{new.total_lines}")
+
+        if diffs:
+            has_diff = True
+            diff_rows.append((i + 1, ", ".join(diffs)))
+
+    # Summary line
+    old_total_ln = sum(s.dedicated_line_nums for s in old_stats)
+    new_total_ln = sum(s.dedicated_line_nums for s in new_stats)
+    old_total_sn = sum(s.single_number_blocks for s in old_stats)
+    new_total_sn = sum(s.single_number_blocks for s in new_stats)
+    old_total_bl = sum(s.total_blocks for s in old_stats)
+    new_total_bl = sum(s.total_blocks for s in new_stats)
+
+    status = "CHANGED" if has_diff else "IDENTICAL"
+    print(f"\n{'='*70}")
+    print(f"  {pdf_name}  [{status}]")
+    print(f"{'='*70}")
+    print(f"  Pages: {n_pages}")
+    print(f"  {'':30s} {'OLD':>10s} {'NEW':>10s} {'DIFF':>10s}")
+    print(f"  {'Total blocks':30s} {old_total_bl:10d} {new_total_bl:10d} {new_total_bl-old_total_bl:+10d}")
+    print(f"  {'Detected line numbers':30s} {old_total_ln:10d} {new_total_ln:10d} {new_total_ln-old_total_ln:+10d}")
+    print(f"  {'Single-number blocks':30s} {old_total_sn:10d} {new_total_sn:10d} {new_total_sn-old_total_sn:+10d}")
+
+    if diff_rows:
+        print(f"\n  Per-page differences:")
+        for page_num, desc in diff_rows:
+            print(f"    Page {page_num:3d}: {desc}")
+    else:
+        print(f"\n  No per-page differences.")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare pdfalto output between a git revision and the current working tree.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("revision", help="Git revision to compare against (tag, branch, commit hash)")
+    parser.add_argument("pdfs", nargs="+", type=Path, help="PDF file(s) to process")
+    parser.add_argument("--keep-tmpdir", action="store_true", help="Don't delete temporary build directory")
+    args = parser.parse_args()
+
+    # Validate PDFs exist
+    for pdf in args.pdfs:
+        if not pdf.exists():
+            sys.exit(f"Error: PDF not found: {pdf}")
+
+    commit = resolve_revision(args.revision)
+    old_label = revision_label(commit)
+    new_label = "current working tree"
+
+    print(f"Comparing:")
+    print(f"  OLD: {old_label}")
+    print(f"  NEW: {new_label}")
+    print()
+
+    tmpdir = Path(tempfile.mkdtemp(prefix="pdfalto-compare-"))
+
+    try:
+        # Build old revision
+        print(f"Building OLD ({args.revision}) ...")
+        old_binary = build_in_worktree(commit, tmpdir)
+        print(f"  -> {old_binary}")
+
+        # Build current
+        print(f"\nBuilding NEW (working tree) ...")
+        new_binary = build_current(tmpdir)
+        print(f"  -> {new_binary}")
+
+        # Process each PDF
+        for pdf in args.pdfs:
+            pdf = pdf.resolve()
+            pdf_name = pdf.name
+
+            old_out = tmpdir / "output-old" / pdf_name.replace(".pdf", ".xml")
+            new_out = tmpdir / "output-new" / pdf_name.replace(".pdf", ".xml")
+            old_out.parent.mkdir(parents=True, exist_ok=True)
+            new_out.parent.mkdir(parents=True, exist_ok=True)
+
+            print(f"\nProcessing {pdf_name} ...")
+
+            ok_old = run_pdfalto(old_binary, pdf, old_out)
+            ok_new = run_pdfalto(new_binary, pdf, new_out)
+
+            if not ok_old:
+                print(f"  WARNING: OLD version failed on {pdf_name}")
+            if not ok_new:
+                print(f"  WARNING: NEW version failed on {pdf_name}")
+
+            if ok_old and ok_new:
+                old_stats = analyze_alto(old_out)
+                new_stats = analyze_alto(new_out)
+                compare_and_report(pdf_name, old_stats, new_stats, old_label, new_label)
+            elif ok_old:
+                old_stats = analyze_alto(old_out)
+                print(f"  OLD only: {len(old_stats)} pages, "
+                      f"{sum(s.total_blocks for s in old_stats)} blocks")
+            elif ok_new:
+                new_stats = analyze_alto(new_out)
+                print(f"  NEW only: {len(new_stats)} pages, "
+                      f"{sum(s.total_blocks for s in new_stats)} blocks")
+
+    finally:
+        cleanup_worktree(commit, tmpdir)
+        # Clean up the in-tree build directory for the current version
+        current_build = REPO_ROOT / "cmake-build-compare"
+        if current_build.exists():
+            shutil.rmtree(current_build, ignore_errors=True)
+        if args.keep_tmpdir:
+            print(f"\nTemporary directory kept at: {tmpdir}")
+        else:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -5142,7 +5142,6 @@ bool TextPage::markLineNumber() {
     // - same font (same font name and same font size)
     // - immediate vertical gap with next token vertically aligned (note that this is actually complicated with the PDF stream order)
 
-    int wordId = 0;
     //int nextVpos = 0;
     //int increment = 0;
 
@@ -5181,8 +5180,8 @@ bool TextPage::markLineNumber() {
                     nextWord = (TextRawWord *) line1->words->get(wordI + 1);
                 else
                     nextWord = NULL;
-                if (wordId != 0)
-                    previousWord = (TextRawWord *) words->get(wordId - 1);
+                if (wordI > 0)
+                    previousWord = (TextRawWord *) line1->words->get(wordI - 1);
                 else
                     previousWord = NULL;
 
@@ -5380,87 +5379,144 @@ bool TextPage::markLineNumber() {
 
     //cout << "nonTrivialClusterSize: " << nonTrivialClusterSize << endl;
 
+    // Count content lines (lines with >1 word, or whose single word is not a number)
+    // to avoid inflating coverage denominator with line-number-only lines
+    int contentLines = 0;
+    for (int pi = 0; pi < blocks->getLength(); pi++) {
+        TextParagraph *p = (TextParagraph *) blocks->get(pi);
+        for (int li = 0; li < p->lines->getLength(); li++) {
+            TextLine *l = (TextLine *) p->lines->get(li);
+            if (l->words->getLength() > 1) {
+                contentLines++;
+            } else if (l->words->getLength() == 1) {
+                TextRawWord *w = (TextRawWord *) l->words->get(0);
+                if (!is_number(w)) {
+                    contentLines++;
+                }
+            }
+        }
+    }
+    if (contentLines == 0)
+        contentLines = 1;
+
+    // neutralize candidate line numbers in the middle of a page with 2 columns
+    // (these are ref numbers in the biblio or something else, but can't be line numbers)
+    int quarterWidth = (rightMostBoundary - leftMostBoundary) / 4;
+
+    // Validate each candidate cluster and collect all valid ones (supports both-margin line numbers)
+    vector<int> validClusterIndices;
     for(int j=0; j<bestClusterIndex.size(); j++) {
         bestCluster = clusters[bestClusterIndex[j]];
         final_vpos = positions[bestClusterIndex[j]];
-        hasLineNumber = true;
-
-        /*cout << "move to next best" << endl;
-        cout << "     final alignment vpos: " << final_vpos << endl;
-        cout << "     size of next best is: " << bestCluster.size() << endl;
-        cout << "     nb numbers best cluster: " << bestCluster.size() << endl;*/
+        bool clusterValid = true;
 
         for (int i = 0; i < textClusters.size(); i++) {
             vector<int> theCluster = textClusters[i];
-            //cout << "cluster size: " << theCluster.size() << endl;
             if (theCluster.size() >= nonTrivialClusterSize) {
-                //word = (TextWord *)textWords->get(theCluster[0]);
                 word = textWords[theCluster[0]];
 
                 // check top and lowest position of the text cluster, if too high or too low,
                 // it means it's head note or foot note and should not be considered
                 int ypos1 = word->yMin;
-                //cout << "ypos1: " << ypos1 << endl;
                 if (ypos1 < 30)
                     continue;
-
-                /*if (theCluster.size() >0) {
-                    lastWord = textWords[theCluster[theCluster.size()-1]];
-                    int ypos2 = word->yMax;
-                    if (pageHeight - ypos2 < 50)
-                        continue;
-                }*/
 
                 int vpos1 = word->xMin-1;
                 int vpos2 = word->xMax+1;
 
-                //cout << "vpos1: " << vpos1 << ", vpos2: " << vpos2 << endl;
                 if ( (vpos1 <= final_vpos) && (vpos2 >= final_vpos)) {
-                    hasLineNumber = false;
-                    //cout << "           breaking text cluster has a size of: " << theCluster.size() << endl;
+                    clusterValid = false;
                     break;
                 }
             }
         }
-        if (hasLineNumber)
-            break;
+
+        if (!clusterValid)
+            continue;
+
+        // reject numbers in the middle of the page (likely bibliography references)
+        if (quarterWidth+leftMostBoundary < final_vpos && final_vpos < leftMostBoundary+(quarterWidth*3))
+            continue;
+
+        // Coverage check against content lines with size-scaled threshold.
+        // Large clusters (>= 30) are accepted regardless of coverage — a cluster of 30+ margin-aligned
+        // numbers is almost certainly line numbers even on table-heavy pages.
+        // Smaller clusters require progressively higher coverage to avoid false positives
+        // from footnote reference numbers (which form small clusters with low coverage).
+        double coverage = (double)bestCluster.size() / contentLines;
+        int clusterSize = (int)bestCluster.size();
+
+        double requiredCoverage;
+        if (clusterSize >= 30)
+            requiredCoverage = 0.0;  // always accept large clusters
+        else if (clusterSize >= 20)
+            requiredCoverage = 0.3;
+        else
+            requiredCoverage = 0.5;
+
+        if (coverage < requiredCoverage)
+            continue;
+        validClusterIndices.push_back(bestClusterIndex[j]);
     }
 
-    if (!hasLineNumber) {
+    if (validClusterIndices.size() == 0) {
         return false;
     }
 
-    // neutralize candidate line numbers in the middle of a page with 2 columns
-    // (these are ref numbers in the biblio or something else, but can't be line numbers)
-    int quarterWidth = (rightMostBoundary - leftMostBoundary) / 4;
-    if (quarterWidth+leftMostBoundary < final_vpos && final_vpos < leftMostBoundary+(quarterWidth*3))
-        hasLineNumber = false;
+    // Deduplicate clusters that represent the same margin (xMin and xMax of the same side).
+    // Since each margin creates two clusters (one for xMin, one for xMax), nearby positions
+    // should be merged by keeping only the largest cluster from each group.
+    double mergeThreshold = 20.0;
+    vector<int> deduplicatedIndices;
+    for (int i = 0; i < validClusterIndices.size(); i++) {
+        double posI = positions[validClusterIndices[i]];
+        int sizeI = clusters[validClusterIndices[i]].size();
+        bool merged = false;
+        for (int k = 0; k < deduplicatedIndices.size(); k++) {
+            double posK = positions[deduplicatedIndices[k]];
+            if (fabs(posI - posK) < mergeThreshold) {
+                // keep the larger cluster
+                int sizeK = clusters[deduplicatedIndices[k]].size();
+                if (sizeI > sizeK) {
+                    deduplicatedIndices[k] = validClusterIndices[i];
+                }
+                merged = true;
+                break;
+            }
+        }
+        if (!merged) {
+            deduplicatedIndices.push_back(validClusterIndices[i]);
+        }
+    }
+    validClusterIndices = deduplicatedIndices;
 
-    if (!hasLineNumber) {
-        return false;
+    // Limit to at most 2 line number columns (left and right margins)
+    if (validClusterIndices.size() > 2) {
+        validClusterIndices.resize(2);
     }
 
-    // increment? it's not possible to suppose any particular increments, it could be 1 by 1 or
-    // 5 by 5 for instance, however number should be growing!
-    // to be done if needed...
-
-    // immediate vertigal gap?
-
-    // Check coverage over the vertical axis
-    double coverage = (double)bestCluster.size() / totalNumberOfLines;
-    if (coverage < 0.3) {  // Require at least 30% coverage
-        return false;
+    // If 2 clusters found, verify they are on opposite sides of the page
+    if (validClusterIndices.size() == 2) {
+        double pos1 = positions[validClusterIndices[0]];
+        double pos2 = positions[validClusterIndices[1]];
+        double midPage = (leftMostBoundary + rightMostBoundary) / 2.0;
+        if (!((pos1 < midPage && pos2 > midPage) || (pos1 > midPage && pos2 < midPage))) {
+            // both on the same side, keep only the largest
+            validClusterIndices.resize(1);
+        }
     }
 
     // final marking of TextWord corresponding to line numbers
-    for (int i = 0; i < bestCluster.size(); i++) {
-        int index = bestCluster[i];
-        word = lineNumberWords[index];
-        // consider only aligned tokens
-        word->setLineNumber(true);
+    for (int vc = 0; vc < validClusterIndices.size(); vc++) {
+        vector<int> theCluster = clusters[validClusterIndices[vc]];
+        for (int i = 0; i < theCluster.size(); i++) {
+            int index = theCluster[i];
+            word = lineNumberWords[index];
+            word->setLineNumber(true);
+        }
     }
 
-    return hasLineNumber;
+    return true;
 }
 
 void TextPage::dump(GBool noLineNumbers, GBool fullFontName, vector<bool> lineNumberStatus) {


### PR DESCRIPTION
This PR addresses the issue #225

The `markLineNumber()` function in `src/XmlAltoOutputDev.cc` had two categories of issues:

1. Wrong variable for previous word lookup (lines 5180-5183)
  The code used wordId (always 0, never incremented) instead of wordI (the loop variable) when looking up the previous word. This caused incorrect neighbor comparisons, breaking detection on many
  pages.

2. Single-cluster logic couldn't handle dual-margin line numbers
  Academic PDFs often have line numbers on both margins (e.g., 1-58 on left, 59-116 on right). The old code picked the first valid cluster and stopped (break), so it could only ever detect one margin
  per page.