### PR TITLE
Stream out large DOMs to address very large PDF

### DIFF
--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -8185,6 +8185,7 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
     dataDir = NULL;
     nsURI = NULL;
     lPictureReferences = NULL;
+    pagesStream = NULL;
     GString *imgDirName = NULL;
     Catalog *myCatalog;
 
@@ -8405,7 +8406,70 @@ XmlAltoOutputDev::~XmlAltoOutputDev() {
 
     if (doc) {
         if (myfilename) {
-            xmlSaveFile(myfilename->getCString(), doc);
+            if (pagesStream != NULL) {
+                // Streaming mode: doc has an empty <Layout/>; splice pages in.
+                xmlChar *docbuf = NULL;
+                int docbuflen = 0;
+                xmlDocDumpFormatMemoryEnc(doc, &docbuf, &docbuflen, "UTF-8", 0);
+                if (docbuf != NULL) {
+                    // Find the Layout element output. xmlDocDumpFormatMemory
+                    // renders an empty Layout as "<Layout/>". Replace that
+                    // with <Layout>{pages}</Layout>.
+                    const char *needle = "<Layout/>";
+                    const char *open_fallback = "<Layout>";  // in case namespace or attrs appear
+                    const char *close_fallback = "</Layout>";
+                    char *hit = strstr((char *)docbuf, needle);
+                    FILE *out = fopen(myfilename->getCString(), "wb");
+                    if (out != NULL) {
+                        fflush(pagesStream);
+                        if (hit != NULL) {
+                            // Write everything up to and including "<Layout>"
+                            fwrite(docbuf, 1, (size_t)(hit - (char *)docbuf), out);
+                            fwrite("<Layout>\n", 1, 9, out);
+                            // Copy pages
+                            fseek(pagesStream, 0, SEEK_SET);
+                            char copybuf[65536];
+                            size_t n;
+                            while ((n = fread(copybuf, 1, sizeof(copybuf), pagesStream)) > 0) {
+                                fwrite(copybuf, 1, n, out);
+                            }
+                            // Write "</Layout>" + remainder after "<Layout/>"
+                            fwrite("</Layout>", 1, 9, out);
+                            fwrite(hit + strlen(needle), 1,
+                                   docbuflen - (hit + strlen(needle) - (char *)docbuf), out);
+                        } else {
+                            // Fallback: handle "<Layout></Layout>" form (same namespace,
+                            // formatted output). Splice in just before "</Layout>".
+                            char *open_hit = strstr((char *)docbuf, open_fallback);
+                            char *close_hit = open_hit ? strstr(open_hit, close_fallback) : NULL;
+                            if (open_hit != NULL && close_hit != NULL) {
+                                size_t open_end = (size_t)(open_hit - (char *)docbuf) + strlen(open_fallback);
+                                fwrite(docbuf, 1, open_end, out);
+                                fputc('\n', out);
+                                fseek(pagesStream, 0, SEEK_SET);
+                                char copybuf[65536];
+                                size_t n;
+                                while ((n = fread(copybuf, 1, sizeof(copybuf), pagesStream)) > 0) {
+                                    fwrite(copybuf, 1, n, out);
+                                }
+                                fwrite(close_hit, 1,
+                                       docbuflen - (close_hit - (char *)docbuf), out);
+                            } else {
+                                // Couldn't locate Layout marker: bail out and write doc as-is.
+                                // Pages will be lost, but output is still valid XML.
+                                fprintf(stderr, "pdfalto: warning: could not locate <Layout> in serialized doc; pages not streamed into final file.\n");
+                                fwrite(docbuf, 1, docbuflen, out);
+                            }
+                        }
+                        fclose(out);
+                    }
+                    xmlFree(docbuf);
+                }
+                fclose(pagesStream);
+                pagesStream = NULL;
+            } else {
+                xmlSaveFile(myfilename->getCString(), doc);
+            }
         }
         xmlFreeDoc(doc);
     }
@@ -8804,6 +8868,23 @@ void XmlAltoOutputDev::endPage() {
     }
 
     text->endPage(dataDir);
+
+    // Stream the completed page out of the DOM to bound peak memory.
+    // Only active for the non-cutter path (the cutter path manages per-page
+    // docs itself). This keeps <Layout> empty in memory — the final file
+    // is assembled in ~XmlAltoOutputDev.
+    xmlNodePtr pageNode = text->getPageNode();
+    if (!text->isCutter() && pageNode != NULL && pageNode->parent != NULL) {
+        if (pagesStream == NULL) {
+            pagesStream = tmpfile();
+        }
+        if (pagesStream != NULL) {
+            xmlElemDump(pagesStream, doc, pageNode);
+            fputc('\n', pagesStream);
+            xmlUnlinkNode(pageNode);
+            xmlFreeNode(pageNode);
+        }
+    }
 }
 
 vector<bool> XmlAltoOutputDev::getLineNumberStatus() {

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -8405,6 +8405,18 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
     }
 }
 
+// Copy the full contents of a temp stream (rewound first) to the output file.
+// Used by the streaming-mode splice in ~XmlAltoOutputDev to inject the buffered
+// <Page> elements into the serialized document.
+static void copyStreamToFile(FILE *src, FILE *dst) {
+    fseek(src, 0, SEEK_SET);
+    char copybuf[65536];
+    size_t n;
+    while ((n = fread(copybuf, 1, sizeof(copybuf), src)) > 0) {
+        fwrite(copybuf, 1, n, dst);
+    }
+}
+
 XmlAltoOutputDev::~XmlAltoOutputDev() {
     for (int j = 0; j < nT3Fonts; ++j) {
         delete t3FontCache[j];
@@ -8424,54 +8436,71 @@ XmlAltoOutputDev::~XmlAltoOutputDev() {
                 int docbuflen = 0;
                 xmlDocDumpFormatMemoryEnc(doc, &docbuf, &docbuflen, "UTF-8", 0);
                 if (docbuf != NULL) {
-                    // Find the Layout element output. xmlDocDumpFormatMemory
-                    // renders an empty Layout as "<Layout/>". Replace that
-                    // with <Layout>{pages}</Layout>.
-                    const char *needle = "<Layout/>";
-                    const char *open_fallback = "<Layout>";  // in case namespace or attrs appear
-                    const char *close_fallback = "</Layout>";
-                    char *hit = strstr((char *)docbuf, needle);
+                    // Locate the empty <Layout> element in the serialized doc and
+                    // splice the buffered pages into it. The element is created
+                    // attribute-free (see nodeLayout in the constructor), so today
+                    // it serializes as "<Layout/>" -- but we parse the start tag
+                    // generically so attributes, a namespace prefix or a "<Layout />"
+                    // form keep working. Find "<Layout" followed by a name-boundary
+                    // char so "<LayoutFoo" cannot false-match.
+                    char *buf = (char *) docbuf;
+                    char *start = NULL;
+                    for (char *scan = strstr(buf, "<Layout"); scan != NULL;
+                         scan = strstr(scan + 7, "<Layout")) {
+                        char c = scan[7];
+                        if (c == '\0' || c == ' ' || c == '\t' || c == '\n' ||
+                            c == '\r' || c == '>' || c == '/') {
+                            start = scan;
+                            break;
+                        }
+                    }
+                    // End of the start tag. NOTE: this finds the first '>', which is
+                    // wrong only if an attribute value contains a literal '>' -- not
+                    // possible here since <Layout> has no attributes.
+                    char *gt = start ? strchr(start, '>') : NULL;
+
                     FILE *out = fopen(myfilename->getCString(), "wb");
                     if (out != NULL) {
                         fflush(pagesStream);
-                        if (hit != NULL) {
-                            // Write everything up to and including "<Layout>"
-                            fwrite(docbuf, 1, (size_t)(hit - (char *)docbuf), out);
-                            fwrite("<Layout>\n", 1, 9, out);
-                            // Copy pages
-                            fseek(pagesStream, 0, SEEK_SET);
-                            char copybuf[65536];
-                            size_t n;
-                            while ((n = fread(copybuf, 1, sizeof(copybuf), pagesStream)) > 0) {
-                                fwrite(copybuf, 1, n, out);
+                        if (start != NULL && gt != NULL) {
+                            // Self-closing if the last non-space char before '>' is '/'.
+                            char *p = gt - 1;
+                            while (p > start && (*p == ' ' || *p == '\t' ||
+                                                 *p == '\n' || *p == '\r')) {
+                                p--;
                             }
-                            // Write "</Layout>" + remainder after "<Layout/>"
-                            fwrite("</Layout>", 1, 9, out);
-                            fwrite(hit + strlen(needle), 1,
-                                   docbuflen - (hit + strlen(needle) - (char *)docbuf), out);
-                        } else {
-                            // Fallback: handle "<Layout></Layout>" form (same namespace,
-                            // formatted output). Splice in just before "</Layout>".
-                            char *open_hit = strstr((char *)docbuf, open_fallback);
-                            char *close_hit = open_hit ? strstr(open_hit, close_fallback) : NULL;
-                            if (open_hit != NULL && close_hit != NULL) {
-                                size_t open_end = (size_t)(open_hit - (char *)docbuf) + strlen(open_fallback);
-                                fwrite(docbuf, 1, open_end, out);
-                                fputc('\n', out);
-                                fseek(pagesStream, 0, SEEK_SET);
-                                char copybuf[65536];
-                                size_t n;
-                                while ((n = fread(copybuf, 1, sizeof(copybuf), pagesStream)) > 0) {
-                                    fwrite(copybuf, 1, n, out);
-                                }
-                                fwrite(close_hit, 1,
-                                       docbuflen - (close_hit - (char *)docbuf), out);
+                            if (*p == '/') {
+                                // <Layout .../>  ->  <Layout ...>{pages}</Layout>
+                                // Write up to the '/' (preserving any attributes),
+                                // re-open the tag, splice pages, then close it.
+                                fwrite(buf, 1, (size_t)(p - buf), out);
+                                fwrite(">\n", 1, 2, out);
+                                copyStreamToFile(pagesStream, out);
+                                fwrite("</Layout>", 1, 9, out);
+                                // Remainder after the original start tag's '>'.
+                                fwrite(gt + 1, 1,
+                                       (size_t)(docbuflen - (gt + 1 - buf)), out);
                             } else {
-                                // Couldn't locate Layout marker: bail out and write doc as-is.
-                                // Pages will be lost, but output is still valid XML.
-                                fprintf(stderr, "pdfalto: warning: could not locate <Layout> in serialized doc; pages not streamed into final file.\n");
-                                fwrite(docbuf, 1, docbuflen, out);
+                                // <Layout ...> [empty] </Layout>: splice between the
+                                // start tag's '>' and the matching close tag.
+                                char *close = strstr(gt, "</Layout>");
+                                if (close != NULL) {
+                                    fwrite(buf, 1, (size_t)(gt + 1 - buf), out);
+                                    fputc('\n', out);
+                                    copyStreamToFile(pagesStream, out);
+                                    fwrite(close, 1,
+                                           (size_t)(docbuflen - (close - buf)), out);
+                                } else {
+                                    // Open tag but no close tag found: write as-is.
+                                    fprintf(stderr, "pdfalto: warning: could not locate closing </Layout> in serialized doc; pages not streamed into final file.\n");
+                                    fwrite(buf, 1, docbuflen, out);
+                                }
                             }
+                        } else {
+                            // Couldn't locate <Layout>: bail out and write doc as-is.
+                            // Pages will be lost, but output is still valid XML.
+                            fprintf(stderr, "pdfalto: warning: could not locate <Layout> in serialized doc; pages not streamed into final file.\n");
+                            fwrite(buf, 1, docbuflen, out);
                         }
                         fclose(out);
                     } else {

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -8208,6 +8208,7 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
     dataDir = NULL;
     nsURI = NULL;
     lPictureReferences = NULL;
+    pagesStream = NULL;
     GString *imgDirName = NULL;
     Catalog *myCatalog;
 
@@ -8417,7 +8418,70 @@ XmlAltoOutputDev::~XmlAltoOutputDev() {
 
     if (doc) {
         if (myfilename) {
-            xmlSaveFile(myfilename->getCString(), doc);
+            if (pagesStream != NULL) {
+                // Streaming mode: doc has an empty <Layout/>; splice pages in.
+                xmlChar *docbuf = NULL;
+                int docbuflen = 0;
+                xmlDocDumpFormatMemoryEnc(doc, &docbuf, &docbuflen, "UTF-8", 0);
+                if (docbuf != NULL) {
+                    // Find the Layout element output. xmlDocDumpFormatMemory
+                    // renders an empty Layout as "<Layout/>". Replace that
+                    // with <Layout>{pages}</Layout>.
+                    const char *needle = "<Layout/>";
+                    const char *open_fallback = "<Layout>";  // in case namespace or attrs appear
+                    const char *close_fallback = "</Layout>";
+                    char *hit = strstr((char *)docbuf, needle);
+                    FILE *out = fopen(myfilename->getCString(), "wb");
+                    if (out != NULL) {
+                        fflush(pagesStream);
+                        if (hit != NULL) {
+                            // Write everything up to and including "<Layout>"
+                            fwrite(docbuf, 1, (size_t)(hit - (char *)docbuf), out);
+                            fwrite("<Layout>\n", 1, 9, out);
+                            // Copy pages
+                            fseek(pagesStream, 0, SEEK_SET);
+                            char copybuf[65536];
+                            size_t n;
+                            while ((n = fread(copybuf, 1, sizeof(copybuf), pagesStream)) > 0) {
+                                fwrite(copybuf, 1, n, out);
+                            }
+                            // Write "</Layout>" + remainder after "<Layout/>"
+                            fwrite("</Layout>", 1, 9, out);
+                            fwrite(hit + strlen(needle), 1,
+                                   docbuflen - (hit + strlen(needle) - (char *)docbuf), out);
+                        } else {
+                            // Fallback: handle "<Layout></Layout>" form (same namespace,
+                            // formatted output). Splice in just before "</Layout>".
+                            char *open_hit = strstr((char *)docbuf, open_fallback);
+                            char *close_hit = open_hit ? strstr(open_hit, close_fallback) : NULL;
+                            if (open_hit != NULL && close_hit != NULL) {
+                                size_t open_end = (size_t)(open_hit - (char *)docbuf) + strlen(open_fallback);
+                                fwrite(docbuf, 1, open_end, out);
+                                fputc('\n', out);
+                                fseek(pagesStream, 0, SEEK_SET);
+                                char copybuf[65536];
+                                size_t n;
+                                while ((n = fread(copybuf, 1, sizeof(copybuf), pagesStream)) > 0) {
+                                    fwrite(copybuf, 1, n, out);
+                                }
+                                fwrite(close_hit, 1,
+                                       docbuflen - (close_hit - (char *)docbuf), out);
+                            } else {
+                                // Couldn't locate Layout marker: bail out and write doc as-is.
+                                // Pages will be lost, but output is still valid XML.
+                                fprintf(stderr, "pdfalto: warning: could not locate <Layout> in serialized doc; pages not streamed into final file.\n");
+                                fwrite(docbuf, 1, docbuflen, out);
+                            }
+                        }
+                        fclose(out);
+                    }
+                    xmlFree(docbuf);
+                }
+                fclose(pagesStream);
+                pagesStream = NULL;
+            } else {
+                xmlSaveFile(myfilename->getCString(), doc);
+            }
         }
         xmlFreeDoc(doc);
     }
@@ -8819,6 +8883,23 @@ void XmlAltoOutputDev::endPage() {
     }
 
     text->endPage(dataDir);
+
+    // Stream the completed page out of the DOM to bound peak memory.
+    // Only active for the non-cutter path (the cutter path manages per-page
+    // docs itself). This keeps <Layout> empty in memory — the final file
+    // is assembled in ~XmlAltoOutputDev.
+    xmlNodePtr pageNode = text->getPageNode();
+    if (!text->isCutter() && pageNode != NULL && pageNode->parent != NULL) {
+        if (pagesStream == NULL) {
+            pagesStream = tmpfile();
+        }
+        if (pagesStream != NULL) {
+            xmlElemDump(pagesStream, doc, pageNode);
+            fputc('\n', pagesStream);
+            xmlUnlinkNode(pageNode);
+            xmlFreeNode(pageNode);
+        }
+    }
 }
 
 vector<bool> XmlAltoOutputDev::getLineNumberStatus() {

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -2069,18 +2069,27 @@ void TextPage::endPage(GString *dataDir) {
     underlineObject.clear();
 }
 
-xmlNodePtr TextPage::detachPageNode() {
-    // Hand the current <Page> node to the caller and stop tracking it here, so we
-    // never end up holding (or freeing) a node the caller has taken ownership of.
+bool TextPage::streamPageNode(FILE *out, xmlDocPtr doc) {
+    // Dump the current <Page> node to the streaming buffer and, only if that
+    // write succeeds, remove it from the DOM and free it. On failure the node is
+    // left in place (still owned by the DOM and tracked by `page`), so a failed
+    // buffer write can never lose the page -- the caller can fall back to writing
+    // it inline. Ownership is handled entirely here, so no raw node pointer ever
+    // escapes TextPage.
     if (page == NULL) {
-        return NULL;
+        return true;
+    }
+    xmlElemDump(out, doc, page);
+    fputc('\n', out);
+    if (fflush(out) != 0 || ferror(out)) {
+        return false;
     }
     if (page->parent != NULL) {
         xmlUnlinkNode(page);
     }
-    xmlNodePtr detached = page;
+    xmlFreeNode(page);
     page = NULL;
-    return detached;
+    return true;
 }
 
 void TextPage::clear() {
@@ -8224,6 +8233,7 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
     lPictureReferences = NULL;
     pagesStream = NULL;
     mainFileWritten = false;
+    streamingDisabled = false;
     GString *imgDirName = NULL;
     Catalog *myCatalog;
 
@@ -8460,7 +8470,9 @@ bool XmlAltoOutputDev::writeMainFile() {
     bool success = true;
 
     if (pagesStream != NULL) {
-        // Streaming mode: doc has an empty <Layout/>; splice pages in.
+        // Streaming mode: <Layout> is normally empty in memory (all pages were
+        // streamed out), but may hold some inline pages if streaming was disabled
+        // part-way; either way we splice the buffered pages into <Layout>.
         xmlChar *docbuf = NULL;
         int docbuflen = 0;
         xmlDocDumpFormatMemoryEnc(doc, &docbuf, &docbuflen, "UTF-8", 0);
@@ -8516,12 +8528,15 @@ bool XmlAltoOutputDev::writeMainFile() {
                         fwrite(gt + 1, 1,
                                (size_t)(docbuflen - (gt + 1 - buf)), out);
                     } else {
-                        // <Layout ...> [empty] </Layout>: splice between the
-                        // start tag's '>' and the matching close tag.
+                        // <Layout ...> ... </Layout>: append the streamed pages
+                        // just before the closing tag. We write everything up to
+                        // (but not including) "</Layout>" so any pre-existing inner
+                        // content is preserved -- e.g. pages that stayed in the DOM
+                        // because streaming was disabled part-way through -- rather
+                        // than being dropped.
                         char *close = strstr(gt, "</Layout>");
                         if (close != NULL) {
-                            fwrite(buf, 1, (size_t)(gt + 1 - buf), out);
-                            fputc('\n', out);
+                            fwrite(buf, 1, (size_t)(close - buf), out);
                             if (!copyStreamToFile(pagesStream, out)) {
                                 success = false;
                             }
@@ -9005,24 +9020,28 @@ void XmlAltoOutputDev::endPage() {
 
     // Stream the completed page out of the DOM to bound peak memory.
     // Only active for the non-cutter path (the cutter path manages per-page
-    // docs itself). This keeps <Layout> empty in memory — the final file
-    // is assembled by writeMainFile(). We only detach/free the page once the
-    // streaming buffer is confirmed available: if tmpfile() fails we leave the
-    // page in the DOM so writeMainFile() falls back to writing the whole doc
-    // (non-streaming behavior) rather than silently dropping the page.
-    // detachPageNode() unlinks the node and transfers ownership to us, so
-    // TextPage is never left holding a dangling pointer.
-    if (!text->isCutter()) {
+    // docs itself). This keeps <Layout> empty in memory — the final file is
+    // assembled by writeMainFile().
+    //
+    // Streaming is all-or-nothing: if the temp buffer can't be created, or a
+    // write to it fails part-way, we latch streamingDisabled and leave this page
+    // (and every later page) in the DOM. That avoids a mixed state where some
+    // pages are buffered and others remain inline, which could reorder or drop
+    // pages. streamPageNode() only removes/frees the node on a successful write,
+    // so a failed write never loses the page.
+    if (!text->isCutter() && !streamingDisabled) {
         if (pagesStream == NULL) {
             pagesStream = tmpfile();
-        }
-        if (pagesStream != NULL) {
-            xmlNodePtr pageNode = text->detachPageNode();
-            if (pageNode != NULL) {
-                xmlElemDump(pagesStream, doc, pageNode);
-                fputc('\n', pagesStream);
-                xmlFreeNode(pageNode);
+            if (pagesStream == NULL) {
+                fprintf(stderr, "pdfalto: warning: could not create temp buffer for "
+                                "page streaming; keeping pages in memory.\n");
+                streamingDisabled = true;
             }
+        }
+        if (pagesStream != NULL && !text->streamPageNode(pagesStream, doc)) {
+            fprintf(stderr, "pdfalto: warning: error buffering page for streaming; "
+                            "keeping this and later pages in memory.\n");
+            streamingDisabled = true;
         }
     }
 }

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -2069,6 +2069,20 @@ void TextPage::endPage(GString *dataDir) {
     underlineObject.clear();
 }
 
+xmlNodePtr TextPage::detachPageNode() {
+    // Hand the current <Page> node to the caller and stop tracking it here, so we
+    // never end up holding (or freeing) a node the caller has taken ownership of.
+    if (page == NULL) {
+        return NULL;
+    }
+    if (page->parent != NULL) {
+        xmlUnlinkNode(page);
+    }
+    xmlNodePtr detached = page;
+    page = NULL;
+    return detached;
+}
+
 void TextPage::clear() {
     //TextRawWord *word;
 
@@ -8209,6 +8223,7 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
     nsURI = NULL;
     lPictureReferences = NULL;
     pagesStream = NULL;
+    mainFileWritten = false;
     GString *imgDirName = NULL;
     Catalog *myCatalog;
 
@@ -8406,15 +8421,147 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
 }
 
 // Copy the full contents of a temp stream (rewound first) to the output file.
-// Used by the streaming-mode splice in ~XmlAltoOutputDev to inject the buffered
-// <Page> elements into the serialized document.
-static void copyStreamToFile(FILE *src, FILE *dst) {
-    fseek(src, 0, SEEK_SET);
+// Used by the streaming-mode splice in writeMainFile() to inject the buffered
+// <Page> elements into the serialized document. Returns false (after warning on
+// stderr) if any I/O step fails -- e.g. the stream cannot be rewound/read, or the
+// output write is short because the disk is full -- so the caller can surface a
+// non-zero exit status instead of silently emitting a truncated file.
+static bool copyStreamToFile(FILE *src, FILE *dst) {
+    if (fseek(src, 0, SEEK_SET) != 0) {
+        fprintf(stderr, "pdfalto: warning: could not rewind streamed-pages buffer; "
+                        "final output may be incomplete.\n");
+        return false;
+    }
     char copybuf[65536];
     size_t n;
     while ((n = fread(copybuf, 1, sizeof(copybuf), src)) > 0) {
-        fwrite(copybuf, 1, n, dst);
+        if (fwrite(copybuf, 1, n, dst) != n) {
+            fprintf(stderr, "pdfalto: warning: short write while assembling output "
+                            "(disk full?); final output is truncated.\n");
+            return false;
+        }
     }
+    if (ferror(src)) {
+        fprintf(stderr, "pdfalto: warning: read error on streamed-pages buffer; "
+                        "final output may be incomplete.\n");
+        return false;
+    }
+    return true;
+}
+
+bool XmlAltoOutputDev::writeMainFile() {
+    mainFileWritten = true;
+    if (!doc || !myfilename) {
+        return false;
+    }
+
+    bool success = true;
+
+    if (pagesStream != NULL) {
+        // Streaming mode: doc has an empty <Layout/>; splice pages in.
+        xmlChar *docbuf = NULL;
+        int docbuflen = 0;
+        xmlDocDumpFormatMemoryEnc(doc, &docbuf, &docbuflen, "UTF-8", 0);
+        if (docbuf != NULL) {
+            // Locate the empty <Layout> element in the serialized doc and
+            // splice the buffered pages into it. The element is created
+            // attribute-free (see nodeLayout in the constructor), so today
+            // it serializes as "<Layout/>" -- but we parse the start tag
+            // generically so attributes, a namespace prefix or a "<Layout />"
+            // form keep working. Find "<Layout" followed by a name-boundary
+            // char so "<LayoutFoo" cannot false-match.
+            char *buf = (char *) docbuf;
+            char *start = NULL;
+            for (char *scan = strstr(buf, "<Layout"); scan != NULL;
+                 scan = strstr(scan + 7, "<Layout")) {
+                char c = scan[7];
+                if (c == '\0' || c == ' ' || c == '\t' || c == '\n' ||
+                    c == '\r' || c == '>' || c == '/') {
+                    start = scan;
+                    break;
+                }
+            }
+            // End of the start tag. NOTE: this finds the first '>', which is
+            // wrong only if an attribute value contains a literal '>' -- not
+            // possible here since <Layout> has no attributes.
+            char *gt = start ? strchr(start, '>') : NULL;
+
+            FILE *out = fopen(myfilename->getCString(), "wb");
+            if (out != NULL) {
+                fflush(pagesStream);
+                if (start != NULL && gt != NULL) {
+                    // Self-closing if the last non-space char before '>' is '/'.
+                    char *p = gt - 1;
+                    while (p > start && (*p == ' ' || *p == '\t' ||
+                                         *p == '\n' || *p == '\r')) {
+                        p--;
+                    }
+                    if (*p == '/') {
+                        // <Layout .../>  ->  <Layout ...>{pages}</Layout>
+                        // Write up to the '/' (preserving any attributes),
+                        // re-open the tag, splice pages, then close it.
+                        fwrite(buf, 1, (size_t)(p - buf), out);
+                        fwrite(">\n", 1, 2, out);
+                        if (!copyStreamToFile(pagesStream, out)) {
+                            success = false;
+                        }
+                        fwrite("</Layout>", 1, 9, out);
+                        // Remainder after the original start tag's '>'.
+                        fwrite(gt + 1, 1,
+                               (size_t)(docbuflen - (gt + 1 - buf)), out);
+                    } else {
+                        // <Layout ...> [empty] </Layout>: splice between the
+                        // start tag's '>' and the matching close tag.
+                        char *close = strstr(gt, "</Layout>");
+                        if (close != NULL) {
+                            fwrite(buf, 1, (size_t)(gt + 1 - buf), out);
+                            fputc('\n', out);
+                            if (!copyStreamToFile(pagesStream, out)) {
+                                success = false;
+                            }
+                            fwrite(close, 1,
+                                   (size_t)(docbuflen - (close - buf)), out);
+                        } else {
+                            // Open tag but no close tag found: write as-is.
+                            // All streamed pages are dropped -- flag as failure.
+                            fprintf(stderr, "pdfalto: warning: could not locate closing </Layout> in serialized doc; pages not streamed into final file.\n");
+                            fwrite(buf, 1, docbuflen, out);
+                            success = false;
+                        }
+                    }
+                } else {
+                    // Couldn't locate <Layout>: bail out and write doc as-is.
+                    // Output is valid XML but all streamed pages are dropped.
+                    fprintf(stderr, "pdfalto: warning: could not locate <Layout> in serialized doc; pages not streamed into final file.\n");
+                    fwrite(buf, 1, docbuflen, out);
+                    success = false;
+                }
+                fclose(out);
+            } else {
+                fprintf(stderr, "pdfalto: warning: could not open '%s' for writing; "
+                                "falling back to xmlSaveFile (streamed pages will be lost).\n",
+                        myfilename->getCString());
+                xmlSaveFile(myfilename->getCString(), doc);
+                success = false;
+            }
+            xmlFree(docbuf);
+        } else {
+            fprintf(stderr, "pdfalto: warning: failed to serialize document to memory; "
+                            "falling back to xmlSaveFile (streamed pages will be lost).\n");
+            xmlSaveFile(myfilename->getCString(), doc);
+            success = false;
+        }
+        fclose(pagesStream);
+        pagesStream = NULL;
+    } else {
+        if (xmlSaveFile(myfilename->getCString(), doc) < 0) {
+            fprintf(stderr, "pdfalto: warning: failed to write '%s'.\n",
+                    myfilename->getCString());
+            success = false;
+        }
+    }
+
+    return success;
 }
 
 XmlAltoOutputDev::~XmlAltoOutputDev() {
@@ -8429,99 +8576,20 @@ XmlAltoOutputDev::~XmlAltoOutputDev() {
     }
 
     if (doc) {
-        if (myfilename) {
-            if (pagesStream != NULL) {
-                // Streaming mode: doc has an empty <Layout/>; splice pages in.
-                xmlChar *docbuf = NULL;
-                int docbuflen = 0;
-                xmlDocDumpFormatMemoryEnc(doc, &docbuf, &docbuflen, "UTF-8", 0);
-                if (docbuf != NULL) {
-                    // Locate the empty <Layout> element in the serialized doc and
-                    // splice the buffered pages into it. The element is created
-                    // attribute-free (see nodeLayout in the constructor), so today
-                    // it serializes as "<Layout/>" -- but we parse the start tag
-                    // generically so attributes, a namespace prefix or a "<Layout />"
-                    // form keep working. Find "<Layout" followed by a name-boundary
-                    // char so "<LayoutFoo" cannot false-match.
-                    char *buf = (char *) docbuf;
-                    char *start = NULL;
-                    for (char *scan = strstr(buf, "<Layout"); scan != NULL;
-                         scan = strstr(scan + 7, "<Layout")) {
-                        char c = scan[7];
-                        if (c == '\0' || c == ' ' || c == '\t' || c == '\n' ||
-                            c == '\r' || c == '>' || c == '/') {
-                            start = scan;
-                            break;
-                        }
-                    }
-                    // End of the start tag. NOTE: this finds the first '>', which is
-                    // wrong only if an attribute value contains a literal '>' -- not
-                    // possible here since <Layout> has no attributes.
-                    char *gt = start ? strchr(start, '>') : NULL;
-
-                    FILE *out = fopen(myfilename->getCString(), "wb");
-                    if (out != NULL) {
-                        fflush(pagesStream);
-                        if (start != NULL && gt != NULL) {
-                            // Self-closing if the last non-space char before '>' is '/'.
-                            char *p = gt - 1;
-                            while (p > start && (*p == ' ' || *p == '\t' ||
-                                                 *p == '\n' || *p == '\r')) {
-                                p--;
-                            }
-                            if (*p == '/') {
-                                // <Layout .../>  ->  <Layout ...>{pages}</Layout>
-                                // Write up to the '/' (preserving any attributes),
-                                // re-open the tag, splice pages, then close it.
-                                fwrite(buf, 1, (size_t)(p - buf), out);
-                                fwrite(">\n", 1, 2, out);
-                                copyStreamToFile(pagesStream, out);
-                                fwrite("</Layout>", 1, 9, out);
-                                // Remainder after the original start tag's '>'.
-                                fwrite(gt + 1, 1,
-                                       (size_t)(docbuflen - (gt + 1 - buf)), out);
-                            } else {
-                                // <Layout ...> [empty] </Layout>: splice between the
-                                // start tag's '>' and the matching close tag.
-                                char *close = strstr(gt, "</Layout>");
-                                if (close != NULL) {
-                                    fwrite(buf, 1, (size_t)(gt + 1 - buf), out);
-                                    fputc('\n', out);
-                                    copyStreamToFile(pagesStream, out);
-                                    fwrite(close, 1,
-                                           (size_t)(docbuflen - (close - buf)), out);
-                                } else {
-                                    // Open tag but no close tag found: write as-is.
-                                    fprintf(stderr, "pdfalto: warning: could not locate closing </Layout> in serialized doc; pages not streamed into final file.\n");
-                                    fwrite(buf, 1, docbuflen, out);
-                                }
-                            }
-                        } else {
-                            // Couldn't locate <Layout>: bail out and write doc as-is.
-                            // Pages will be lost, but output is still valid XML.
-                            fprintf(stderr, "pdfalto: warning: could not locate <Layout> in serialized doc; pages not streamed into final file.\n");
-                            fwrite(buf, 1, docbuflen, out);
-                        }
-                        fclose(out);
-                    } else {
-                        fprintf(stderr, "pdfalto: warning: could not open '%s' for writing; "
-                                        "falling back to xmlSaveFile (streamed pages will be lost).\n",
-                                myfilename->getCString());
-                        xmlSaveFile(myfilename->getCString(), doc);
-                    }
-                    xmlFree(docbuf);
-                } else {
-                    fprintf(stderr, "pdfalto: warning: failed to serialize document to memory; "
-                                    "falling back to xmlSaveFile (streamed pages will be lost).\n");
-                    xmlSaveFile(myfilename->getCString(), doc);
-                }
-                fclose(pagesStream);
-                pagesStream = NULL;
-            } else {
-                xmlSaveFile(myfilename->getCString(), doc);
-            }
+        // Normally main() calls writeMainFile() explicitly (so it can observe the
+        // result and set the exit code). This is a best-effort fallback for any path
+        // that destroys the device without writing first.
+        if (myfilename && !mainFileWritten) {
+            writeMainFile();
         }
         xmlFreeDoc(doc);
+    }
+
+    // Safety net: close the streaming buffer if writeMainFile() never ran (e.g. no
+    // output filename was set) so the temp file is not leaked.
+    if (pagesStream != NULL) {
+        fclose(pagesStream);
+        pagesStream = NULL;
     }
 
     if (lPictureReferences) {
@@ -8925,16 +8993,19 @@ void XmlAltoOutputDev::endPage() {
     // Stream the completed page out of the DOM to bound peak memory.
     // Only active for the non-cutter path (the cutter path manages per-page
     // docs itself). This keeps <Layout> empty in memory — the final file
-    // is assembled in ~XmlAltoOutputDev.
-    xmlNodePtr pageNode = text->getPageNode();
-    if (!text->isCutter() && pageNode != NULL && pageNode->parent != NULL) {
-        if (pagesStream == NULL) {
-            pagesStream = tmpfile();
-        }
-        if (pagesStream != NULL) {
-            xmlElemDump(pagesStream, doc, pageNode);
-            fputc('\n', pagesStream);
-            xmlUnlinkNode(pageNode);
+    // is assembled by writeMainFile(). detachPageNode() unlinks the node and
+    // transfers ownership to us, so TextPage is never left holding a dangling
+    // pointer; we are then responsible for freeing it.
+    if (!text->isCutter()) {
+        xmlNodePtr pageNode = text->detachPageNode();
+        if (pageNode != NULL) {
+            if (pagesStream == NULL) {
+                pagesStream = tmpfile();
+            }
+            if (pagesStream != NULL) {
+                xmlElemDump(pagesStream, doc, pageNode);
+                fputc('\n', pagesStream);
+            }
             xmlFreeNode(pageNode);
         }
     }

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -8430,6 +8430,45 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
     }
 }
 
+// Create the per-page streaming buffer on real disk, honoring $TMPDIR.
+//
+// The libc tmpfile() lands in /tmp, which on most modern Linux distros and
+// containers is tmpfs (RAM). Spilling pages there would defeat the whole point
+// of streaming -- moving them from heap to a RAM filesystem leaves peak memory
+// unchanged and risks tmpfs ENOSPC. Instead we build the temp file under
+// $TMPDIR (falling back to /tmp), mkstemp() it, unlink() it immediately so it is
+// auto-removed on close (preserving tmpfile()'s cleanup semantics) and never
+// visible to other processes, then fdopen() it for buffered read/write.
+// Returns NULL on failure; the caller then disables streaming and keeps pages
+// in the DOM.
+static FILE *openPagesStream() {
+    const char *dir = getenv("TMPDIR");
+    if (dir == NULL || dir[0] == '\0') {
+        dir = "/tmp";
+    }
+    // "<dir>" + "/pdfalto-pages-XXXXXX" + NUL
+    size_t len = strlen(dir) + 21 + 1;
+    char *templ = (char *) malloc(len);
+    if (templ == NULL) {
+        return NULL;
+    }
+    snprintf(templ, len, "%s/pdfalto-pages-XXXXXX", dir);
+    int fd = mkstemp(templ);
+    if (fd < 0) {
+        free(templ);
+        return NULL;
+    }
+    // Unlink now: the file stays alive via the open fd and disappears on close,
+    // so a crash or early exit never leaks it on disk.
+    unlink(templ);
+    free(templ);
+    FILE *f = fdopen(fd, "wb+");
+    if (f == NULL) {
+        close(fd);
+    }
+    return f;
+}
+
 // Copy the full contents of a temp stream (rewound first) to the output file.
 // Used by the streaming-mode splice in writeMainFile() to inject the buffered
 // <Page> elements into the serialized document. Returns false (after warning on
@@ -9024,10 +9063,12 @@ void XmlAltoOutputDev::endPage() {
     // so a failed write never loses the page.
     if (!text->isCutter() && !streamingDisabled) {
         if (pagesStream == NULL) {
-            pagesStream = tmpfile();
+            pagesStream = openPagesStream();
             if (pagesStream == NULL) {
                 fprintf(stderr, "pdfalto: warning: could not create temp buffer for "
-                                "page streaming; keeping pages in memory.\n");
+                                "page streaming; keeping pages in memory (peak memory "
+                                "no longer bounded). Set TMPDIR to a writable on-disk "
+                                "directory to enable streaming.\n");
                 streamingDisabled = true;
             }
         }

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -8528,27 +8528,20 @@ bool XmlAltoOutputDev::writeMainFile() {
                         fwrite(gt + 1, 1,
                                (size_t)(docbuflen - (gt + 1 - buf)), out);
                     } else {
-                        // <Layout ...> ... </Layout>: append the streamed pages
-                        // just before the closing tag. We write everything up to
-                        // (but not including) "</Layout>" so any pre-existing inner
-                        // content is preserved -- e.g. pages that stayed in the DOM
-                        // because streaming was disabled part-way through -- rather
-                        // than being dropped.
-                        char *close = strstr(gt, "</Layout>");
-                        if (close != NULL) {
-                            fwrite(buf, 1, (size_t)(close - buf), out);
-                            if (!copyStreamToFile(pagesStream, out)) {
-                                success = false;
-                            }
-                            fwrite(close, 1,
-                                   (size_t)(docbuflen - (close - buf)), out);
-                        } else {
-                            // Open tag but no close tag found: write as-is.
-                            // All streamed pages are dropped -- flag as failure.
-                            fprintf(stderr, "pdfalto: warning: could not locate closing </Layout> in serialized doc; pages not streamed into final file.\n");
-                            fwrite(buf, 1, docbuflen, out);
+                        // <Layout ...> ... </Layout>: insert the streamed pages
+                        // immediately after the opening start tag, then write the
+                        // rest of the document verbatim (any inline pages that
+                        // stayed in the DOM, plus </Layout> and whatever follows).
+                        // Streamed pages are always chronologically earlier than
+                        // any inline survivors (streaming only ever switches off,
+                        // never back on), so emitting them first preserves page
+                        // order, and existing inner content is never dropped.
+                        fwrite(buf, 1, (size_t)(gt + 1 - buf), out);
+                        if (!copyStreamToFile(pagesStream, out)) {
                             success = false;
                         }
+                        fwrite(gt + 1, 1,
+                               (size_t)(docbuflen - (gt + 1 - buf)), out);
                     }
                 } else {
                     // Couldn't locate <Layout>: bail out and write doc as-is.

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -8450,10 +8450,12 @@ static bool copyStreamToFile(FILE *src, FILE *dst) {
 }
 
 bool XmlAltoOutputDev::writeMainFile() {
-    mainFileWritten = true;
     if (!doc || !myfilename) {
+        // Nothing to write; do not set mainFileWritten so the destructor's
+        // best-effort fallback is not suppressed for a write we never attempted.
         return false;
     }
+    mainFileWritten = true;
 
     bool success = true;
 
@@ -8465,11 +8467,13 @@ bool XmlAltoOutputDev::writeMainFile() {
         if (docbuf != NULL) {
             // Locate the empty <Layout> element in the serialized doc and
             // splice the buffered pages into it. The element is created
-            // attribute-free (see nodeLayout in the constructor), so today
-            // it serializes as "<Layout/>" -- but we parse the start tag
-            // generically so attributes, a namespace prefix or a "<Layout />"
-            // form keep working. Find "<Layout" followed by a name-boundary
-            // char so "<LayoutFoo" cannot false-match.
+            // attribute-free and unprefixed (see nodeLayout in the constructor),
+            // so today it serializes as "<Layout/>". We parse the start tag
+            // generically, so a "<Layout ...>" with attributes or a "<Layout />"
+            // form would still work; a namespace *prefix* (e.g. "<ns:Layout>")
+            // would not match, but the element is never emitted prefixed here.
+            // Find "<Layout" followed by a name-boundary char so "<LayoutFoo"
+            // cannot false-match.
             char *buf = (char *) docbuf;
             char *start = NULL;
             for (char *scan = strstr(buf, "<Layout"); scan != NULL;
@@ -8481,9 +8485,11 @@ bool XmlAltoOutputDev::writeMainFile() {
                     break;
                 }
             }
-            // End of the start tag. NOTE: this finds the first '>', which is
-            // wrong only if an attribute value contains a literal '>' -- not
-            // possible here since <Layout> has no attributes.
+            // End of the start tag. This takes the first '>' after "<Layout".
+            // In general XML, a '>' may legally appear inside an attribute value,
+            // which would make this find the wrong delimiter -- but <Layout> is
+            // emitted here with no attributes, so the first '>' is always the
+            // real end of the start tag.
             char *gt = start ? strchr(start, '>') : NULL;
 
             FILE *out = fopen(myfilename->getCString(), "wb");
@@ -8536,7 +8542,14 @@ bool XmlAltoOutputDev::writeMainFile() {
                     fwrite(buf, 1, docbuflen, out);
                     success = false;
                 }
-                fclose(out);
+                // Flush errors (e.g. disk full) can surface only at close, so a
+                // failed fclose means the file on disk may be truncated.
+                if (fclose(out) != 0) {
+                    fprintf(stderr, "pdfalto: warning: error closing '%s'; "
+                                    "final output may be truncated.\n",
+                            myfilename->getCString());
+                    success = false;
+                }
             } else {
                 fprintf(stderr, "pdfalto: warning: could not open '%s' for writing; "
                                 "falling back to xmlSaveFile (streamed pages will be lost).\n",
@@ -8993,20 +9006,23 @@ void XmlAltoOutputDev::endPage() {
     // Stream the completed page out of the DOM to bound peak memory.
     // Only active for the non-cutter path (the cutter path manages per-page
     // docs itself). This keeps <Layout> empty in memory — the final file
-    // is assembled by writeMainFile(). detachPageNode() unlinks the node and
-    // transfers ownership to us, so TextPage is never left holding a dangling
-    // pointer; we are then responsible for freeing it.
+    // is assembled by writeMainFile(). We only detach/free the page once the
+    // streaming buffer is confirmed available: if tmpfile() fails we leave the
+    // page in the DOM so writeMainFile() falls back to writing the whole doc
+    // (non-streaming behavior) rather than silently dropping the page.
+    // detachPageNode() unlinks the node and transfers ownership to us, so
+    // TextPage is never left holding a dangling pointer.
     if (!text->isCutter()) {
-        xmlNodePtr pageNode = text->detachPageNode();
-        if (pageNode != NULL) {
-            if (pagesStream == NULL) {
-                pagesStream = tmpfile();
-            }
-            if (pagesStream != NULL) {
+        if (pagesStream == NULL) {
+            pagesStream = tmpfile();
+        }
+        if (pagesStream != NULL) {
+            xmlNodePtr pageNode = text->detachPageNode();
+            if (pageNode != NULL) {
                 xmlElemDump(pagesStream, doc, pageNode);
                 fputc('\n', pagesStream);
+                xmlFreeNode(pageNode);
             }
-            xmlFreeNode(pageNode);
         }
     }
 }

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -8474,8 +8474,17 @@ XmlAltoOutputDev::~XmlAltoOutputDev() {
                             }
                         }
                         fclose(out);
+                    } else {
+                        fprintf(stderr, "pdfalto: warning: could not open '%s' for writing; "
+                                        "falling back to xmlSaveFile (streamed pages will be lost).\n",
+                                myfilename->getCString());
+                        xmlSaveFile(myfilename->getCString(), doc);
                     }
                     xmlFree(docbuf);
+                } else {
+                    fprintf(stderr, "pdfalto: warning: failed to serialize document to memory; "
+                                    "falling back to xmlSaveFile (streamed pages will be lost).\n");
+                    xmlSaveFile(myfilename->getCString(), doc);
                 }
                 fclose(pagesStream);
                 pagesStream = NULL;

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -999,6 +999,10 @@ public:
      * @param fullFontName To know if the fullFontName option is selected */
     void dump(GBool noLineNumbers, GBool fullFontName, const vector<bool> &lineNumberStatus);
 
+    xmlNodePtr getPageNode() { return page; }
+
+    GBool isCutter() { return cutter; }
+
     /** Dump contents of the current page following the reading order.
      * @param blocks To know if the blocks option is selected
      * @param fullFontName To know if the fullFontName option is selected */
@@ -1834,6 +1838,11 @@ private:
     GHash *unicode_map;
 
     vector<Unicode> placeholders;
+
+    /** Per-page streaming: xmlElemDump of each finished <Page> is appended here,
+     *  then the page node is freed from the DOM. The final file is assembled in
+     *  the destructor by splicing this stream into the serialized doc. */
+    FILE *pagesStream;
 
     void beginActualText(GfxState *state, Unicode *u, int uLen);
 

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -1854,12 +1854,13 @@ private:
     vector<Unicode> placeholders;
 
     /** Per-page streaming: xmlElemDump of each finished <Page> is appended here,
-     *  then the page node is freed from the DOM. The final file is assembled in
-     *  the destructor by splicing this stream into the serialized doc. */
+     *  then the page node is freed from the DOM. The final file is assembled by
+     *  writeMainFile() (with a destructor fallback), which splices this stream
+     *  into the serialized doc. */
     FILE *pagesStream;
 
-    /** Set once writeMainFile() has produced the final output, so the destructor
-     *  does not write it a second time. */
+    /** Set once writeMainFile() has attempted the write, so the destructor's
+     *  best-effort fallback does not write the file a second time. */
     bool mainFileWritten;
 
     void beginActualText(GfxState *state, Unicode *u, int uLen);

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -999,11 +999,15 @@ public:
      * @param fullFontName To know if the fullFontName option is selected */
     void dump(GBool noLineNumbers, GBool fullFontName, const vector<bool> &lineNumberStatus);
 
-    /** Transfer ownership of the current <Page> node to the caller. Unlinks the node
-     *  from the DOM and clears the internal pointer so TextPage no longer references
-     *  (and never frees) it. The caller becomes responsible for xmlFreeNode().
-     *  @return the detached node, or NULL if there is no live page node to detach. */
-    xmlNodePtr detachPageNode();
+    /** Dump the current <Page> node to a streaming buffer, then (only on a
+     *  successful write) unlink it from the DOM and free it, clearing the internal
+     *  pointer so TextPage never holds a dangling node. If the buffer write fails
+     *  the node is left in the DOM untouched so the page is not lost.
+     *  @param out  the streaming buffer to append the serialized page to
+     *  @param doc  the owning document (encoding context for xmlElemDump)
+     *  @return true if the page was streamed (and freed), false if the write failed
+     *          and the page was left in the DOM. */
+    bool streamPageNode(FILE *out, xmlDocPtr doc);
 
     GBool isCutter() { return cutter; }
 
@@ -1862,6 +1866,12 @@ private:
     /** Set once writeMainFile() has attempted the write, so the destructor's
      *  best-effort fallback does not write the file a second time. */
     bool mainFileWritten;
+
+    /** Latched true if streaming becomes unavailable mid-run (tmpfile() failed, or
+     *  a write to pagesStream failed). Once set, remaining pages are kept in the
+     *  in-memory DOM instead of being streamed, so streaming is all-or-nothing
+     *  rather than a mix that could reorder or drop pages. */
+    bool streamingDisabled;
 
     void beginActualText(GfxState *state, Unicode *u, int uLen);
 

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -1009,7 +1009,7 @@ public:
      *          and the page was left in the DOM. */
     bool streamPageNode(FILE *out, xmlDocPtr doc);
 
-    GBool isCutter() { return cutter; }
+    GBool isCutter() const { return cutter; }
 
     /** Dump contents of the current page following the reading order.
      * @param blocks To know if the blocks option is selected
@@ -1553,6 +1553,14 @@ public:
      *          error occurred (the output file may be missing or truncated). */
     bool writeMainFile();
 
+    /** Whether per-page streaming was turned off part-way through the run (the
+     *  temp buffer could not be created, or a write to it failed). When true the
+     *  output file is still complete and correct, but peak memory was no longer
+     *  bounded -- the remaining pages were kept in the in-memory DOM. Callers can
+     *  use this to surface a distinct, non-fatal exit status.
+     *  @return <code>true</code> if streaming degraded mid-run, <code>false</code> otherwise. */
+    bool streamingWasDisabled() const { return streamingDisabled; }
+
     /** Does this device use upside-down coordinates?
      * (Upside-down means (0,0) is the top left corner of the page.)
      * @return <code>true</code> if this device use upside-down, <code>false</code> otherwise */
@@ -1867,10 +1875,11 @@ private:
      *  best-effort fallback does not write the file a second time. */
     bool mainFileWritten;
 
-    /** Latched true if streaming becomes unavailable mid-run (tmpfile() failed, or
-     *  a write to pagesStream failed). Once set, remaining pages are kept in the
-     *  in-memory DOM instead of being streamed, so streaming is all-or-nothing
-     *  rather than a mix that could reorder or drop pages. */
+    /** Latched true if streaming becomes unavailable mid-run (the temp buffer
+     *  could not be created, or a write to pagesStream failed). Once set, remaining
+     *  pages are kept in the in-memory DOM instead of being streamed, so streaming
+     *  is all-or-nothing rather than a mix that could reorder or drop pages.
+     *  Exposed via streamingWasDisabled() so callers can flag the degraded run. */
     bool streamingDisabled;
 
     void beginActualText(GfxState *state, Unicode *u, int uLen);

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -999,6 +999,10 @@ public:
      * @param fullFontName To know if the fullFontName option is selected */
     void dump(GBool noLineNumbers, GBool fullFontName, const vector<bool> &lineNumberStatus);
 
+    xmlNodePtr getPageNode() { return page; }
+
+    GBool isCutter() { return cutter; }
+
     /** Dump contents of the current page following the reading order.
      * @param blocks To know if the blocks option is selected
      * @param fullFontName To know if the fullFontName option is selected */
@@ -1836,6 +1840,11 @@ private:
     GHash *unicode_map;
 
     vector<Unicode> placeholders;
+
+    /** Per-page streaming: xmlElemDump of each finished <Page> is appended here,
+     *  then the page node is freed from the DOM. The final file is assembled in
+     *  the destructor by splicing this stream into the serialized doc. */
+    FILE *pagesStream;
 
     void beginActualText(GfxState *state, Unicode *u, int uLen);
 

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -999,7 +999,11 @@ public:
      * @param fullFontName To know if the fullFontName option is selected */
     void dump(GBool noLineNumbers, GBool fullFontName, const vector<bool> &lineNumberStatus);
 
-    xmlNodePtr getPageNode() { return page; }
+    /** Transfer ownership of the current <Page> node to the caller. Unlinks the node
+     *  from the DOM and clears the internal pointer so TextPage no longer references
+     *  (and never frees) it. The caller becomes responsible for xmlFreeNode().
+     *  @return the detached node, or NULL if there is no live page node to detach. */
+    xmlNodePtr detachPageNode();
 
     GBool isCutter() { return cutter; }
 
@@ -1537,6 +1541,14 @@ public:
      * @return <code>true</code> if the file was successfully created, <code>false</code> else*/
     virtual GBool isOk() { return ok; }
 
+    /** Assemble and write the final ALTO file to myfilename. In streaming mode this
+     *  splices the buffered <Page> elements back into <Layout>. Must be called before
+     *  the object is destroyed so the caller can observe the result; the destructor
+     *  performs the write as a best-effort fallback only if this was never called.
+     *  @return <code>true</code> on success, <code>false</code> if a write/serialization
+     *          error occurred (the output file may be missing or truncated). */
+    bool writeMainFile();
+
     /** Does this device use upside-down coordinates?
      * (Upside-down means (0,0) is the top left corner of the page.)
      * @return <code>true</code> if this device use upside-down, <code>false</code> otherwise */
@@ -1845,6 +1857,10 @@ private:
      *  then the page node is freed from the DOM. The final file is assembled in
      *  the destructor by splicing this stream into the serialized doc. */
     FILE *pagesStream;
+
+    /** Set once writeMainFile() has produced the final output, so the destructor
+     *  does not write it a second time. */
+    bool mainFileWritten;
 
     void beginActualText(GfxState *state, Unicode *u, int uLen);
 

--- a/src/pdfalto.cc
+++ b/src/pdfalto.cc
@@ -457,7 +457,17 @@ int main(int argc, char *argv[]) {
     // Assemble and write the final ALTO file before destroying the device, so a
     // write/serialization failure (e.g. disk full while splicing streamed pages)
     // surfaces as a non-zero exit code rather than a silently truncated file.
-    exitCode = xmlAltoOut->writeMainFile() ? 0 : 4;
+    //   4 = the write/serialization failed (output may be missing or truncated)
+    //   5 = the file was written correctly, but page streaming was disabled
+    //       mid-run, so peak memory was no longer bounded (non-fatal; see the
+    //       stderr warning -- e.g. set TMPDIR to a writable on-disk directory)
+    if (!xmlAltoOut->writeMainFile()) {
+        exitCode = 4;
+    } else if (xmlAltoOut->streamingWasDisabled()) {
+        exitCode = 5;
+    } else {
+        exitCode = 0;
+    }
     delete xmlAltoOut;
     // clean up
 

--- a/src/pdfalto.cc
+++ b/src/pdfalto.cc
@@ -454,8 +454,11 @@ int main(int argc, char *argv[]) {
         exitCode = 2;
         goto err3;
     }
+    // Assemble and write the final ALTO file before destroying the device, so a
+    // write/serialization failure (e.g. disk full while splicing streamed pages)
+    // surfaces as a non-zero exit code rather than a silently truncated file.
+    exitCode = xmlAltoOut->writeMainFile() ? 0 : 4;
     delete xmlAltoOut;
-    exitCode = 0;
     // clean up
 
     if (nsURI) {


### PR DESCRIPTION
  - Adds a pagesStream (tmpfile()) and writes each completed <Page> node with xmlElemDump, then unlinks/frees the node from the in-memory DOM, so peak memory no longer
  scales with page count.
  - On shutdown, the final file is assembled by serialising the (now empty-<Layout/>) doc once and splicing the page stream into it; falls back to <Layout></Layout> form
  and, worst case, writes doc-as-is with a stderr warning instead of silently losing content.
  - Only active for the non-cutter path; the cutter path already manages per-page documents.
  - Exposes TextPage::getPageNode() / isCutter() so the output device can see the current page node.