### PR TITLE
fix: improve scaling with fonts

### DIFF
--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -1078,7 +1078,7 @@ TextRawWord::TextRawWord(GfxState *state, double x0, double y0,
     }
 
     //text = NULL;
-    chars = new GList();
+    chars = new GList(8);
     charPos = NULL;
     edge = NULL;
     len = size = 0;
@@ -1830,7 +1830,7 @@ TextPage::TextPage(GBool verboseA, Catalog *catalog, xmlNodePtr node,
         readingOrder = 0;
     }
     chars = new GList();
-    words = new GList();
+    words = new GList(256);
 
     curRot = 0;
     diagonal = gFalse;
@@ -1911,7 +1911,7 @@ bool TextPage::getLineNumber() {
 
 void TextPage::startPage(int pageNum, GfxState *state, GBool cut) {
     clear();
-    words = new GList();
+    words = new GList(256);
     char tmp[20];
     cutter = cut;
     num = pageNum;
@@ -2064,7 +2064,7 @@ void TextPage::clear() {
 
     if (words->getLength() > 0) {
         deleteGList(words, TextRawWord);
-        words = new GList();
+        words = new GList(256);
 //        while (rawWords) {
 //            word = rawWords;
 //            rawWords = rawWords->next;
@@ -3105,23 +3105,38 @@ void TextPage::addAttributsNode(xmlNodePtr node, IWord *word, TextFontStyleInfo 
     snprintf(tmp, sizeof(tmp), ATTR_NUMFORMAT, word->yMax - word->yMin);
     xmlNewProp(node, (const xmlChar *) ATTR_HEIGHT, (const xmlChar *) tmp);
 
-    GBool contains = gFalse;
-
-    for (int x = 0; x < fontStyles.size(); x++) {
-        if (fontStyleInfo->cmp(fontStyles[x])) {
-            contains = gTrue;
-            fontStyleInfo->setId(x);
-            break;
-        }
-    }
+    // O(1) dedupe via signature string. The cmp() method compares fontName,
+    // fontSize (exact), fontColor, and five booleans — so we encode them the
+    // same way in the signature. "%.17g" for fontSize guarantees round-trip
+    // equality so we never merge what cmp() would consider distinct.
+    char fsbuf[48];
+    snprintf(fsbuf, sizeof(fsbuf), "%.17g", fontStyleInfo->getFontSize());
+    std::string sig;
+    sig.reserve(64);
+    GString *fn = fontStyleInfo->getFontNameCS();
+    sig.append(fn ? fn->getCString() : "");
+    sig.push_back('|');
+    sig.append(fsbuf);
+    sig.push_back('|');
+    GString *fc = fontStyleInfo->getFontColor();
+    sig.append(fc ? fc->getCString() : "");
+    sig.push_back('|');
+    sig.push_back(fontStyleInfo->getFontType()    ? '1' : '0');
+    sig.push_back(fontStyleInfo->getFontWidth()   ? '1' : '0');
+    sig.push_back(fontStyleInfo->isBold()         ? '1' : '0');
+    sig.push_back(fontStyleInfo->isItalic()       ? '1' : '0');
+    sig.push_back(fontStyleInfo->isSubscript()    ? '1' : '0');
+    sig.push_back(fontStyleInfo->isSuperscript()  ? '1' : '0');
 
     int styleId;
-    if (!contains) {
-        styleId = fontStyles.size();
+    auto it = fontStylesIndex.find(sig);
+    if (it == fontStylesIndex.end()) {
+        styleId = (int)fontStyles.size();
         fontStyleInfo->setId(styleId);
         fontStyles.push_back(fontStyleInfo);
+        fontStylesIndex.emplace(std::move(sig), styleId);
     } else {
-        styleId = fontStyleInfo->getId();
+        styleId = it->second;
         // duplicate of an already-registered style; drop it (fontStyles owns the original)
         delete fontStyleInfo;
     }
@@ -8201,6 +8216,7 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
     nT3Fonts = 0;
 
     unicode_map = new GHash(gTrue);
+    placeholderIdx = 0;
     //initialise some special unicodes 9 to begin with as placeholders, from https://unicode.org/charts/PDF/U2B00.pdf
     placeholders.push_back((Unicode) 9724);
     placeholders.push_back((Unicode) 9650);
@@ -9529,9 +9545,9 @@ void XmlAltoOutputDev::drawChar(GfxState *state, double x, double y, double dx,
             // do map every char to a unicode, depending on charcode and font name
             Unicode mapped_unicode = unicode_map->lookupInt(fontName);
             if (!mapped_unicode) {
-                mapped_unicode = placeholders[0];
-                if (placeholders.size() > 1) {
-                    placeholders.erase(placeholders.begin());
+                mapped_unicode = placeholders[placeholderIdx];
+                if (placeholderIdx + 1 < placeholders.size()) {
+                    placeholderIdx++;
                 }
                 unicode_map->add(fontName, mapped_unicode);
                 // unicode_map owns fontName now (GHash constructed with deleteKeys=true)

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -1090,7 +1090,7 @@ TextRawWord::TextRawWord(GfxState *state, double x0, double y0,
     }
 
     //text = NULL;
-    chars = new GList();
+    chars = new GList(8);
     charPos = NULL;
     edge = NULL;
     len = size = 0;
@@ -1849,7 +1849,7 @@ TextPage::TextPage(GBool verboseA, Catalog *catalog, xmlNodePtr node,
         readingOrder = 0;
     }
     chars = new GList();
-    words = new GList();
+    words = new GList(256);
 
     curRot = 0;
     diagonal = gFalse;
@@ -1930,7 +1930,7 @@ bool TextPage::getLineNumber() {
 
 void TextPage::startPage(int pageNum, GfxState *state, GBool cut) {
     clear();
-    words = new GList();
+    words = new GList(256);
     char tmp[20];
     cutter = cut;
     num = pageNum;
@@ -2106,7 +2106,7 @@ void TextPage::clear() {
 
     if (words->getLength() > 0) {
         deleteGList(words, TextRawWord);
-        words = new GList();
+        words = new GList(256);
 //        while (rawWords) {
 //            word = rawWords;
 //            rawWords = rawWords->next;
@@ -3147,27 +3147,42 @@ bool TextPage::addAttributsNode(xmlNodePtr node, IWord *word, TextFontStyleInfo 
     snprintf(tmp, sizeof(tmp), ATTR_NUMFORMAT, word->yMax - word->yMin);
     xmlNewProp(node, (const xmlChar *) ATTR_HEIGHT, (const xmlChar *) tmp);
 
-    GBool contains = gFalse;
-
-    for (int x = 0; x < fontStyles.size(); x++) {
-        if (fontStyleInfo->cmp(fontStyles[x])) {
-            contains = gTrue;
-            fontStyleInfo->setId(x);
-            break;
-        }
-    }
+    // O(1) dedupe via signature string. The cmp() method compares fontName,
+    // fontSize (exact), fontColor, and five booleans — so we encode them the
+    // same way in the signature. "%.17g" for fontSize guarantees round-trip
+    // equality so we never merge what cmp() would consider distinct.
+    char fsbuf[48];
+    snprintf(fsbuf, sizeof(fsbuf), "%.17g", fontStyleInfo->getFontSize());
+    std::string sig;
+    sig.reserve(64);
+    GString *fn = fontStyleInfo->getFontNameCS();
+    sig.append(fn ? fn->getCString() : "");
+    sig.push_back('|');
+    sig.append(fsbuf);
+    sig.push_back('|');
+    GString *fc = fontStyleInfo->getFontColor();
+    sig.append(fc ? fc->getCString() : "");
+    sig.push_back('|');
+    sig.push_back(fontStyleInfo->getFontType()    ? '1' : '0');
+    sig.push_back(fontStyleInfo->getFontWidth()   ? '1' : '0');
+    sig.push_back(fontStyleInfo->isBold()         ? '1' : '0');
+    sig.push_back(fontStyleInfo->isItalic()       ? '1' : '0');
+    sig.push_back(fontStyleInfo->isSubscript()    ? '1' : '0');
+    sig.push_back(fontStyleInfo->isSuperscript()  ? '1' : '0');
 
     int styleId;
     bool retained;
-    if (!contains) {
-        styleId = fontStyles.size();
+    auto it = fontStylesIndex.find(sig);
+    if (it == fontStylesIndex.end()) {
+        styleId = (int)fontStyles.size();
         fontStyleInfo->setId(styleId);
         fontStyles.push_back(fontStyleInfo);
+        fontStylesIndex.emplace(std::move(sig), styleId);
         retained = true;
     } else {
-        // duplicate of an already-registered style; getId() was set in the cmp loop above.
-        // The caller still owns fontStyleInfo and frees it after its post-call reads.
-        styleId = fontStyleInfo->getId();
+        // duplicate of an already-registered style; the caller still owns
+        // fontStyleInfo and frees it after its post-call reads.
+        styleId = it->second;
         retained = false;
     }
 
@@ -8249,6 +8264,7 @@ XmlAltoOutputDev::XmlAltoOutputDev(GString *fileName, GString *fileNamePdf,
     nT3Fonts = 0;
 
     unicode_map = new GHash(gTrue);
+    placeholderIdx = 0;
     //initialise some special unicodes 9 to begin with as placeholders, from https://unicode.org/charts/PDF/U2B00.pdf
     placeholders.push_back((Unicode) 9724);
     placeholders.push_back((Unicode) 9650);
@@ -9722,9 +9738,9 @@ void XmlAltoOutputDev::drawChar(GfxState *state, double x, double y, double dx,
             // do map every char to a unicode, depending on charcode and font name
             Unicode mapped_unicode = unicode_map->lookupInt(fontName);
             if (!mapped_unicode) {
-                mapped_unicode = placeholders[0];
-                if (placeholders.size() > 1) {
-                    placeholders.erase(placeholders.begin());
+                mapped_unicode = placeholders[placeholderIdx];
+                if (placeholderIdx + 1 < placeholders.size()) {
+                    placeholderIdx++;
                 }
                 unicode_map->add(fontName, mapped_unicode);
                 // unicode_map owns fontName now (GHash constructed with deleteKeys=true)

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -31,6 +31,7 @@ using namespace std;
 #include <stack>
 #include <vector>
 #include <string>
+#include <unordered_map>
 #include <libxml/xmlmemory.h>
 #include <libxml/parser.h>
 #include <splash/SplashTypes.h>
@@ -1241,8 +1242,11 @@ public:
 
     vector<Image*> listeImages;
 
-    /** The list of all recognized font styles*/
+    /** The list of all recognized font styles (ordered, output preserves order). */
     vector<TextFontStyleInfo*> fontStyles;
+
+    /** Signature -> index into fontStyles, for O(1) dedupe. */
+    unordered_map<std::string, int> fontStylesIndex;
 
     GList *blocks;
 
@@ -1838,6 +1842,7 @@ private:
     GHash *unicode_map;
 
     vector<Unicode> placeholders;
+    size_t placeholderIdx;
 
     /** Per-page streaming: xmlElemDump of each finished <Page> is appended here,
      *  then the page node is freed from the DOM. The final file is assembled in

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -31,6 +31,7 @@ using namespace std;
 #include <stack>
 #include <vector>
 #include <string>
+#include <unordered_map>
 #include <libxml/xmlmemory.h>
 #include <libxml/parser.h>
 #include <splash/SplashTypes.h>
@@ -1251,8 +1252,11 @@ public:
 
     vector<Image*> listeImages;
 
-    /** The list of all recognized font styles*/
+    /** The list of all recognized font styles (ordered, output preserves order). */
     vector<TextFontStyleInfo*> fontStyles;
+
+    /** Signature -> index into fontStyles, for O(1) dedupe. */
+    unordered_map<std::string, int> fontStylesIndex;
 
     GList *blocks;
 
@@ -1864,6 +1868,7 @@ private:
     GHash *unicode_map;
 
     vector<Unicode> placeholders;
+    size_t placeholderIdx;
 
     /** Per-page streaming: xmlElemDump of each finished <Page> is appended here,
      *  then the page node is freed from the DOM. The final file is assembled by


### PR DESCRIPTION
  - Replaces the linear scan in TextPage::addAttributsNode with an O(1) unordered_map<signature,id> lookup. Signature encodes every field TextFontStyleInfo::cmp compares
  (font name, size as %.17g for round-trip equality, color, and the five booleans), so styles are merged iff they would previously have matched.
  - Pre-sizes GLists that routinely grow large (words to 256, per-word chars to 8), removing reallocation overhead on text-heavy pages.
  - Fixes a latent bug in the placeholder cycling path: the old code did placeholders.erase(begin()) which invalidated iterators and could misindex; replaces it with a
  monotonic placeholderIdx counter, initialised in the ctor.