### PR TITLE
Fix segfault on annotations with QuadPoints but unsupported subtype (#148)

### DIFF
--- a/src/AnnotsXrce.cc
+++ b/src/AnnotsXrce.cc
@@ -58,6 +58,13 @@ AnnotsXrce::AnnotsXrce(Object &objA, xmlNodePtr docrootA, Catalog *catalog, doub
     for (int i = 0; i < objA.arrayGetLength(); ++i) {
         objA.arrayGet(i, &kid);
         if (kid.isDict()) {
+            // Reset the per-annotation node pointers so that an unsupported
+            // annotation (e.g. Squiggly/StrikeOut) does not inherit, or attach
+            // its children to, the node of a previously processed one (#148).
+            nodeAnnot = NULL;
+            nodePopup = NULL;
+            nodeContent = NULL;
+            isLink = gFalse;
             Dict *dict;
             dict = kid.getDict();
             char tmpor[100];
@@ -85,15 +92,17 @@ AnnotsXrce::AnnotsXrce(Object &objA, xmlNodePtr docrootA, Catalog *catalog, doub
 
 
             // Get informations about Link annotation
-            if (isLink) {
+            // Without a host annotation node there is nowhere to attach the action
+            // subtree, and the locals below would stay unset (#148).
+            if (isLink && nodeAnnot) {
                 Link *link = new Link(dict, catalog->getBaseURI());
                 //printf("%d \n",link->isOk());
                 LinkAction *ac = link->getAction();
                 //printf("ac %d \n",ac->isOk());
                 // Get the Action information
                 if (ac != NULL && ac->isOk()) {
-                    xmlNodePtr nodeActionAction;
-                    xmlNodePtr nodeActionDEST;
+                    xmlNodePtr nodeActionAction = NULL;
+                    xmlNodePtr nodeActionDEST = NULL;
                     if (nodeAnnot) {
                         nodeActionAction = xmlNewNode(NULL, (const xmlChar *) TAG_ACTION);
                         nodeActionAction->type = XML_ELEMENT_NODE;
@@ -381,7 +390,7 @@ AnnotsXrce::AnnotsXrce(Object &objA, xmlNodePtr docrootA, Catalog *catalog, doub
 
             // Get the popup's contents
             if (dict->lookup("RC", &objContents)->isString()) {
-                if (nodeAnnot) {
+                if (nodeAnnot && nodePopup) {
                     nodeContent = xmlNewNode(NULL, (const xmlChar *) TAG_RICH_CONTENT);
                     nodeContent->type = XML_ELEMENT_NODE;
                     //to unicode first
@@ -410,9 +419,9 @@ AnnotsXrce::AnnotsXrce(Object &objA, xmlNodePtr docrootA, Catalog *catalog, doub
 
             // Get the localization (points series) of the annotation into the page
             if (dict->lookup("QuadPoints", &objQuadPoints)->isArray()) {
-                xmlNodePtr nodeQuad;
-                xmlNodePtr nodeQuadril;
-                xmlNodePtr nodePoints;
+                xmlNodePtr nodeQuad = NULL;
+                xmlNodePtr nodeQuadril = NULL;
+                xmlNodePtr nodePoints = NULL;
 
                 if (nodeAnnot) {
                     nodeQuad = xmlNewNode(NULL, (const xmlChar *) TAG_QUADPOINTS);
@@ -423,7 +432,10 @@ AnnotsXrce::AnnotsXrce(Object &objA, xmlNodePtr docrootA, Catalog *catalog, doub
                 char temp[10];
                 double xx = 0;
                 double yy = 0;
-                for (int j = 0; j < objQuadPoints.arrayGetLength(); ++j) {
+                // Only build the QuadPoints subtree when we have a host annotation
+                // node; unsupported subtypes (Squiggly/StrikeOut) also carry
+                // QuadPoints but leave nodeQuad unset, which would crash xmlAddChild (#148).
+                for (int j = 0; nodeAnnot && j < objQuadPoints.arrayGetLength(); ++j) {
                     objQuadPoints.arrayGet(j, &point);
 
                     if (j % 8 == 0) {


### PR DESCRIPTION
`pdfalto -annotation` crashed on PDFs containing markup annotations that carry a
`QuadPoints` array but whose `Subtype` is not one of the five handled ones.

`AnnotsXrce::AnnotsXrce()` only creates the host node `nodeAnnot` for `Text`,
`Highlight`, `Underline`, `FreeText` and `Link`. Everything else -- including
`Squiggly` and `StrikeOut`, which the code comments already call out as
unsupported -- leaves `nodeAnnot` unset. The `QuadPoints` block, however, was
entered on the presence of the array alone, and guarded only the *creation* of
`nodeQuad`, not the loop that populates it. So the loop ran with `nodeQuad`
uninitialised and handed it to `xmlAddChild()` as the parent. libxml
dereferenced it in `xmlNodeSetDoc` and the process died. AddressSanitizer on the
reporter's file pinpointed the `xmlAddChild(nodeQuad, ...)` call.

The underlying problem is broader than that one block: all the per-annotation
state (`nodeAnnot`, `nodePopup`, `nodeContent`, `isLink`) is declared *outside*
the loop over the annotation array and was never reset between iterations. An
unsupported annotation therefore ran with the previous annotation's pointers and
flags. Where those were still set, it silently attached its children to the
wrong annotation; where they were not, it crashed.

### The fix

All in `src/AnnotsXrce.cc`:

- **Reset the per-annotation state at the top of each iteration** --
  `nodeAnnot` / `nodePopup` / `nodeContent` / `isLink`. This is what stops the
  cross-annotation grafting.
- **Guard the `QuadPoints` subtree on `nodeAnnot`.** The loop condition now
  carries `nodeAnnot &&`, so the subtree is built only when there is a host node
  to attach it to. Unsupported subtypes contribute nothing, which is the
  intended behaviour.
- **Guard the Link action subtree on `nodeAnnot`**, and initialise
  `nodeActionAction` / `nodeActionDEST` to `NULL`. These had the identical
  defect: assigned only inside `if (nodeAnnot)` but written to unconditionally
  by the action `switch` below. It was latent only because `nodeAnnot` was never
  NULL once the first supported annotation had been seen.
- **Guard the rich-content insertion on `nodePopup`.** The `RC` branch checked
  `nodeAnnot` but attached to `nodePopup` -- the same NULL-parent crash for an
  annotation with rich content but no `Popup`.

The local `nodeQuad` / `nodeQuadril` / `nodePoints` are likewise initialised to
`NULL` rather than left indeterminate.

### Validation

Two reproducers, both segfaulting on master and both clean under
AddressSanitizer with the fix:

**1. The reporter's `TUW-217619.pdf`** -- now exits 0 and emits its 8 `Text`
annotations.

**2. [`Klug.Hahn.2021 - Conversational Interfaces and Digital Empathy.pdf`](https://github.com/kermitt2/grobid/files/11847848/Klug.Hahn.2021.-.Conversational.Interfaces.and.Digital.Empathy.pdf)**
-- a 4-page file whose annotations are:

| subtype | count | has `QuadPoints` |
|---|---|---|
| `StrikeOut` | 1 | yes |
| `Popup` | 2 | no |
| `Caret` | 1 | no |

This is the minimal case: `StrikeOut` is exactly the subtype the source comment
names as unsupported, and it is the only annotation carrying `QuadPoints`. On
master, ASan gives

```
SEGV on unknown address 0x000000000000 in xmlNodeSetDoc
  xmlAddChild
  AnnotsXrce::AnnotsXrce   src/AnnotsXrce.cc:432
  PDFDocXrce::displayPages src/PDFDocXrce.cc:57
  main                     src/pdfalto.cc:436
```

-- `AnnotsXrce.cc:432` being `xmlAddChild(nodeQuad, nodeQuadril)`, the same site
as the reporter's file. Without `-annotation` the same binary processes the file
fine, confirming the crash is confined to this path.

With the fix it exits 0, ASan-clean, and emits `<ANNOTATIONS/>`. That empty
result is correct rather than a silent drop: all four annotations in the file
are of unsupported subtypes, so there is nothing to emit.

Full corpus, 5,927 PDFs (PMC 1,943 / bioRxiv 2,000 / PLOS 1,000 / eLife 984),
run with `-annotation` against master (`f6406cc`), both binaries built from the
same xpdf submodule (`eb5f219`):

| | master | this PR |
|---|---|---|
| crashes / timeouts | 0 | 0 |
| annotation files emitted | 5,927 | 5,927 |
| unparseable output | 0 | 0 |
| `<ANNOTATION>` elements | 765,162 | 765,162 (+0) |
| quadpoint elements | 1,518,333 | 1,518,177 (-156) |
| files with different output | – | 29 |

No annotation is gained or lost anywhere -- per-file `<ANNOTATION>` counts are
identical across all 5,927. The 29 differing files are all the silent-grafting
case, and in every one the fix *removes* children that master had attached to
the wrong annotation:

| | files | what master emitted |
|---|---|---|
| grafted quadrilaterals | 27 | e.g. `btt-5-007`: Link `p1_a4` carries 3 `QUADRILATERAL`s, only 1 of them its own |
| grafted author / popup | 2 | e.g. `262162v1`: a duplicate `<AUTHOR>` and a second empty `<POPUP>` inside one annotation |

Note that the corpus contains **no** instance of the crash itself -- every one of
the 5,927 files runs clean on master too. The reporter's PDF remains the only
reproducer for the segfault; what the corpus validates is the grafting fix and
the absence of regressions.

