### PR TITLE
Fix negative token width for glyphs wrapped after a diacritic (#192)

### DIFF
--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -2935,21 +2935,29 @@ void TextPage::addCharToRawWord(GfxState *state, double x, double y, double dx,
                 ((TextChar *) curWord->chars->get(curWord->chars->getLength() - 1))->spaceAfter =
                         (char) gTrue;
         }
-        // A combining mark is drawn on the same baseline as the glyph it
-        // modifies, so the diacritic-driven break suppression below is only
-        // valid within a single line. When the baseline shifts by more than the
-        // same-line tolerance, this glyph belongs to a different line (e.g. a
-        // character wrapped to the next line); the break must not be suppressed,
-        // otherwise the wrapped glyph is glued onto the previous word and the
-        // resulting token gets a negative width (issue #192).
+        // A combining mark sits on or beside the glyph it modifies: it shares the
+        // baseline and it is never far to the left of the word built so far. A
+        // glyph that breaks both of those -- different baseline *and* starting a
+        // whole font size or more before the end of the current word -- has
+        // wrapped to the next line and is not a mark on this word. Gluing it on
+        // produces a token whose width is negative (issue #192), so the
+        // diacritic break-suppression below must not apply to it.
+        //
+        // Both halves are needed. Baseline alone is far too broad: accents drawn
+        // raised above their base letter shift the baseline on the *same* line,
+        // and splitting there breaks ordinary words apart. Measured over the
+        // GROBID end-to-end corpus, sp/fontSize never goes below -0.79 for those
+        // same-line marks, while wrapped glyphs reach -67, so the two populations
+        // separate cleanly at one font size.
         GBool sameBaseline = fabs(base - curWord->base) <= 1;
+        GBool wrappedToNextLine = !sameBaseline && sp < -curWord->fontSize;
 
         // take into account rotation angle ??
         if ( (overlap ||
               fabs(base - curWord->base) > 1 ||
               space ||
               (sp < -minDupBreakOverlap * curWord->fontSize))
-              && (modifierClass == NOT_A_MODIFIER || !sameBaseline)) {
+              && (modifierClass == NOT_A_MODIFIER || wrappedToNextLine)) {
             endWord();
             beginWord(state, x, y);
         }

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -2935,12 +2935,21 @@ void TextPage::addCharToRawWord(GfxState *state, double x, double y, double dx,
                 ((TextChar *) curWord->chars->get(curWord->chars->getLength() - 1))->spaceAfter =
                         (char) gTrue;
         }
+        // A combining mark is drawn on the same baseline as the glyph it
+        // modifies, so the diacritic-driven break suppression below is only
+        // valid within a single line. When the baseline shifts by more than the
+        // same-line tolerance, this glyph belongs to a different line (e.g. a
+        // character wrapped to the next line); the break must not be suppressed,
+        // otherwise the wrapped glyph is glued onto the previous word and the
+        // resulting token gets a negative width (issue #192).
+        GBool sameBaseline = fabs(base - curWord->base) <= 1;
+
         // take into account rotation angle ??
-        if ( (overlap || 
+        if ( (overlap ||
               fabs(base - curWord->base) > 1 ||
               space ||
-              (sp < -minDupBreakOverlap * curWord->fontSize)) 
-              && modifierClass == NOT_A_MODIFIER) {
+              (sp < -minDupBreakOverlap * curWord->fontSize))
+              && (modifierClass == NOT_A_MODIFIER || !sameBaseline)) {
             endWord();
             beginWord(state, x, y);
         }

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -2317,165 +2317,19 @@ void TextPage::beginWord(GfxState *state, double x0, double y0) {
     curWord = new TextRawWord(state, x0, y0, curFont, curFontSize, getIdWORD(), getIdx());
 }
 
-ModifierClass TextPage::classifyChar(Unicode u) {
-    switch (u) {
-        case (Unicode) 776: //COMBINING DIAERESIS
-        case (Unicode) 168: //DIAERESIS
-            return DIAERESIS;
-
-        case 833:
-        case 779: // COMBINING DOUBLE_ACUTE_ACCENT
-        case 733:
-            return DOUBLE_ACUTE_ACCENT;
-        case 180:
-        case 769: //COMBINING
-        case 714:
-            return ACUTE_ACCENT;
-
-        case 768: //COMBINING
-        case 832:
-        case 715:
-        case 96:
-            return GRAVE_ACCENT;
-
-        case 783: //COMBINING
-            return DOUBLE_GRAVE_ACCENT;
-
-        case 774: //COMBINING
-        case 728:
-            //case '\uA67C':
-            return BREVE_ACCENT;
-
-        case 785: //COMBINING
-        case 1156:
-        case 1159:
-            return INVERTED_BREVE_ACCENT;
-
-
-        case 770: //COMBINING
-        case 94:
-        case 710:
-            return CIRCUMFLEX;
-
-
-        case 771: //COMBINING
-        case 126:
-        case 732:
-            return TILDE;
-
-        case 778: //COMBINING
-        case 176:
-        case 730:
-            return NORDIC_RING;//LOOK AT UNICODE RING BELOW...
-
-        case 780: //COMBINING
-        case 711:
-            return CZECH_CARON;
-
-        case 807: //COMBINING
-        case 184:
-            return CEDILLA;
-
-        case 775: //COMBINING
-        case 729:
-            return DOT_ABOVE;
-
-        case 777: //COMBINING
-        case 704:
-            return HOOK;
-
-        case 795: //COMBINING
-            return HORN;
-
-        case 808: //COMBINING
-        case 731:
-            //case '\u1AB7':// combining open mark below
-            return OGONEK;
-
-        case 772: //COMBINING
-        case 175:
-        case 713:
-            return MACRON;
-        default:
-            return NOT_A_MODIFIER;
-    }
-
-}
-
-/*
- * Returns the correct base char for composition with icu4c following unicode standard.
- */
-Unicode IWord::getStandardBaseChar(Unicode c) {
-    switch (c) {
-        case 305:
-            return 105;
-        default:
-            return c;
-    }
-}
-
-Unicode TextPage::getCombiningDiacritic(ModifierClass modifierClass) {
-
-    Unicode diactritic = 0;
-    switch (modifierClass) {
-        case DIAERESIS:
-            diactritic = 776;
-            break;
-        case ACUTE_ACCENT:
-            diactritic = 769;
-            break;
-        case GRAVE_ACCENT:
-            diactritic = 768;
-            break;
-        case CIRCUMFLEX:
-            diactritic = 770;
-            break;
-        case TILDE:
-            diactritic = 771;
-            break;
-        case NORDIC_RING:
-            diactritic = 778;
-            break;
-        case CZECH_CARON:
-            diactritic = 780;
-            break;
-        case CEDILLA:
-            diactritic = 807;
-            break;
-        case DOUBLE_ACUTE_ACCENT:
-            diactritic = 779;
-            break;
-        case DOUBLE_GRAVE_ACCENT:
-            diactritic = 783;
-            break;
-        case BREVE_ACCENT:
-            diactritic = 785;
-            break;
-        case INVERTED_BREVE_ACCENT:
-            diactritic = 785;
-            break;
-        case DOT_ABOVE:
-            diactritic = 775;
-            break;
-        case HOOK:
-            diactritic = 777;
-            break;
-        case HORN:
-            diactritic = 795;
-            break;
-        case OGONEK:
-            diactritic = 808;
-            break;
-        case MACRON:
-            diactritic = 772;
-            break;
-        default:
-            break;
-    }
-    return diactritic;
-}
-
-ModifierClass IWord::classifyChar(Unicode u) {
+// Single source of truth for combining-mark classification.
+//
+// This table used to be duplicated as TextPage::classifyChar and
+// IWord::classifyChar, and the two copies had drifted: the TextPage one also
+// listed U+00B0 DEGREE SIGN as NORDIC_RING. Both were live -- TextPage's from
+// addCharToRawWord, IWord's from TextRawWord::addChar -- so the same character
+// was a combining mark for one word-break decision and not for another.
+//
+// The degree sign is a standalone symbol, not a combining mark; classifying it
+// as one suppressed the word break and glued axis labels such as "40 deg N"
+// into unusable tokens. U+02DA RING ABOVE (730) and U+030A COMBINING RING
+// ABOVE (778) remain, as those genuinely are marks.
+static ModifierClass classifyModifierChar(Unicode u) {
     switch (u) {
         case (Unicode) 776: //COMBINING DIAERESIS
         case (Unicode) 168: //DIAERESIS
@@ -2559,6 +2413,83 @@ ModifierClass IWord::classifyChar(Unicode u) {
     }
 
 }
+
+ModifierClass TextPage::classifyChar(Unicode u) { return classifyModifierChar(u); }
+
+/*
+ * Returns the correct base char for composition with icu4c following unicode standard.
+ */
+Unicode IWord::getStandardBaseChar(Unicode c) {
+    switch (c) {
+        case 305:
+            return 105;
+        default:
+            return c;
+    }
+}
+
+Unicode TextPage::getCombiningDiacritic(ModifierClass modifierClass) {
+
+    Unicode diactritic = 0;
+    switch (modifierClass) {
+        case DIAERESIS:
+            diactritic = 776;
+            break;
+        case ACUTE_ACCENT:
+            diactritic = 769;
+            break;
+        case GRAVE_ACCENT:
+            diactritic = 768;
+            break;
+        case CIRCUMFLEX:
+            diactritic = 770;
+            break;
+        case TILDE:
+            diactritic = 771;
+            break;
+        case NORDIC_RING:
+            diactritic = 778;
+            break;
+        case CZECH_CARON:
+            diactritic = 780;
+            break;
+        case CEDILLA:
+            diactritic = 807;
+            break;
+        case DOUBLE_ACUTE_ACCENT:
+            diactritic = 779;
+            break;
+        case DOUBLE_GRAVE_ACCENT:
+            diactritic = 783;
+            break;
+        case BREVE_ACCENT:
+            diactritic = 785;
+            break;
+        case INVERTED_BREVE_ACCENT:
+            diactritic = 785;
+            break;
+        case DOT_ABOVE:
+            diactritic = 775;
+            break;
+        case HOOK:
+            diactritic = 777;
+            break;
+        case HORN:
+            diactritic = 795;
+            break;
+        case OGONEK:
+            diactritic = 808;
+            break;
+        case MACRON:
+            diactritic = 772;
+            break;
+        default:
+            break;
+    }
+    return diactritic;
+}
+
+ModifierClass IWord::classifyChar(Unicode u) { return classifyModifierChar(u); }
 
 Unicode IWord::getCombiningDiacritic(ModifierClass modifierClass) {
 


### PR DESCRIPTION
A word break at a line wrap was suppressed when the preceding glyph was a
combining mark. The wrapped glyph was glued onto the word from the previous
line, so the resulting token ran from the end of one line back to the start of
the next and its `WIDTH` came out negative.

The diacritic break-suppression is now restricted to glyphs that really are on
the same line, so a glyph wrapped to the next line starts a new token.

### Distinguishing a wrap from an accent

The first attempt overrode the suppression whenever the baseline shifted. That
is too broad: accents are drawn raised above their base letter, so they shift
the baseline on the *same* line too, and ordinary words were split apart --
"Álvarez" came out as `"´"` + `"lvarez"`.

Measured over the GROBID end-to-end corpus (5,927 PDFs), that condition changed
1,209 files while only 297 of them had any negative width to fix. The other 912
were split for nothing, adding 12,591 spurious tokens.

Baseline shift cannot separate the two cases -- as a ratio to font size it is
0.24 median where the bug is present and 0.21 where it is not. The horizontal
gap can. A combining mark sits on its letter, so `sp` (the distance from the end
of the current word to the start of the incoming glyph) never drops below -0.79
font sizes. A wrapped glyph restarts at the left margin and reaches -67. The two
populations do not overlap.

The break-suppression is therefore overridden only when both hold: the baseline
shifted *and* the glyph starts a whole font size or more to the left.

```c
GBool wrappedToNextLine = !sameBaseline && sp < -curWord->fontSize;
```

### Also: deduplicate classifyChar, and stop treating the degree sign as a mark

The combining-mark table existed twice, as `TextPage::classifyChar` and
`IWord::classifyChar` -- 84 identical lines apart from one entry: the `TextPage`
copy also listed `U+00B0 DEGREE SIGN` as `NORDIC_RING`. Both were live
(`TextPage`'s via `addCharToRawWord`, `IWord`'s via `TextRawWord::addChar`), so
the same character counted as a combining mark for one word-break decision and
not for another. The third caller, `TextWord::TextWord`, sits inside an `#if 0`
block and is never compiled.

The degree sign is a standalone symbol, not a combining mark. Classifying it as
one suppressed the word break and ran axis labels together -- a map figure came
out as `"0°0"`, `"°20°4"`, `"0°N"`, `"60°8"` instead of `"0°"`, `"20°"`,
`"40°N"`, `"60°"`. `U+02DA RING ABOVE` and `U+030A COMBINING RING ABOVE` remain,
as those are genuine marks.

Both methods now forward to a single file-scope `classifyModifierChar()`, so the
two call sites can no longer disagree. The header and every call site are
unchanged. The function uses no member state, which is why the duplication went
unnoticed.

### Validation

Full corpus, 5,927 PDFs, against master:

| | files changed | tokens | negative WIDTH left | crashes |
|---|---|---|---|---|
| master | – | – | 536 | 0 |
| baseline-only override (first attempt) | 1,209 | +12,591 | 19 | 0 |
| narrowed | 308 | +392 | 41 | 0 |
| **narrowed + classifyChar fix (this PR)** | **394** | **+905** | **37** | 0 |

93% of the negative widths are removed while touching a third as many files as
the first attempt. No crashes, timeouts or unparseable output.

### Known remaining

37 negative-`WIDTH` tokens survive, in 10 files. 30 of them are single glyphs
(`f`, `β`, `ŷ`, `ψ`, `φ`) whose own width computes slightly negative -- 17 are
under one unit. A single glyph cannot be a wrapped glyph glued to a previous
word, so no word-break rule addresses these; they are a glyph-metrics issue and
are tracked with the glyph handling work. The other 7 are genuine #192-class
composites this threshold does not catch, the clearest being a `"Fig."` token at
`WIDTH="-474.08"`.
