### PR TITLE
Fix nondeterministic output: uninitialised read and use-after-free

### DIFF
--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -547,7 +547,6 @@ TextWord::TextWord(GList *charsA, int start, int lenA,
                    int rotA, int dirA, GBool spaceAfterA, GfxState *state,
                    TextFontInfo *fontA, double fontSizeA, int idCurrentWord,
                    int index) {
-    GfxFont *gfxFont;
     double ascent, descent;
 
     TextChar *chPrev, *ch;
@@ -698,15 +697,17 @@ TextWord::TextWord(GList *charsA, int start, int lenA,
 
     fontSize = fontSizeA;
 
-    if ((gfxFont = font->gfxFont)) {
-        ascent = gfxFont->getAscent() * fontSize;
-        descent = gfxFont->getDescent() * fontSize;
+    if (font->hasGfxFont()) {
+        // Read the metrics cached by TextFontInfo instead of dereferencing
+        // font->gfxFont: that GfxFont may already have been destroyed along with
+        // its GfxFontDict when the enclosing form's resources were popped.
+        ascent = font->getAscent() * fontSize;
+        descent = font->getDescent() * fontSize;
     } else {
         // this means that the PDF file draws text without a current font,
         // which should never happen
         ascent = 0.95 * fontSize;
         descent = -0.35 * fontSize;
-        gfxFont = NULL;
     }
 
     len = lenA;
@@ -884,7 +885,6 @@ TextWord::~TextWord() {
 TextRawWord::TextRawWord(GfxState *state, double x0, double y0,
                          TextFontInfo *fontA, double fontSizeA, int idCurrentWord,
                          int index) {
-    GfxFont *gfxFont;
     double x, y, ascent, descent;
 
     charLen = 0;
@@ -1023,15 +1023,17 @@ TextRawWord::TextRawWord(GfxState *state, double x0, double y0,
     fontSize = fontSizeA;
 
     state->transform(x0, y0, &x, &y);
-    if ((gfxFont = font->gfxFont)) {
-        ascent = gfxFont->getAscent() * fontSize;
-        descent = gfxFont->getDescent() * fontSize;
+    if (font->hasGfxFont()) {
+        // Read the metrics cached by TextFontInfo instead of dereferencing
+        // font->gfxFont: that GfxFont may already have been destroyed along with
+        // its GfxFontDict when the enclosing form's resources were popped.
+        ascent = font->getAscent() * fontSize;
+        descent = font->getDescent() * fontSize;
     } else {
         // this means that the PDF file draws text without a current font,
         // which should never happen
         ascent = 0.95 * fontSize;
         descent = -0.35 * fontSize;
-        gfxFont = NULL;
     }
 
     // Rotation cases

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -895,6 +895,12 @@ TextRawWord::TextRawWord(GfxState *state, double x0, double y0,
     symbolic = gFalse;
     lineNumber = false;
 
+    // addCharToRawWord() only ever calls setSpaceAfter(gTrue), so without this
+    // a word with no space after it keeps whatever was in the freshly allocated
+    // memory. TextPage::dump() tests this flag to decide whether to emit an <SP>,
+    // which made the default (non reading-order) output depend on heap contents.
+    spaceAfter = gFalse;
+
     double *fontm;
     double m[4];
     double m2[4];

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -131,6 +131,17 @@ public:
     GBool isSymbolic() { return flags & fontSymbolic; }
     GBool isItalic() { return flags & fontItalic; }
     GBool isBold() { return flags & fontBold; }
+
+    // Ascent/descent as captured (and sanitised) when this TextFontInfo was
+    // built. Callers must use these rather than reaching through to the
+    // GfxFont: a word can outlive the font it refers to, because the GfxFontDict
+    // owning it is destroyed when the enclosing form's resources are popped.
+    double getAscent() { return ascent; }
+    double getDescent() { return descent; }
+
+    // Whether a GfxFont was present at construction time. The pointer itself
+    // may since have been freed, so it must never be dereferenced.
+    GBool hasGfxFont() { return gfxFont != NULL; }
 //#endif
 
 private:


### PR DESCRIPTION
Two independent memory bugs in the text layout path. Together they made pdfalto's
output depend on heap contents rather than on the input PDF.

## 1. `TextRawWord::spaceAfter` was never initialised

`addCharToRawWord()` only ever calls `setSpaceAfter(gTrue)` — nothing sets the flag
false, and the constructor left it unassigned. A word with no space after it
therefore kept whatever happened to be in the freshly allocated memory, and
`TextPage::dump()` tests exactly that flag to decide whether to emit an `<SP>`
element.

This is on the only live output path. `TextRawWord` is the sole word class actually
constructed: the one route to `new TextWord` is
`endPage -> dumpInReadingOrder -> buildColumns -> buildColumns2 -> buildColumn ->
buildLines -> buildLine`, and that call site is commented out at
`XmlAltoOutputDev.cc:9062`, so `TextWord` is never instantiated. `-readingOrder` is
unaffected by that — it is handled inside `dump()` itself.

The output was consequently not reproducible. On `korean_document.pdf`, varying only
the allocator fill pattern:

| `MALLOC_PERTURB_` | 0 | 1 | 170 | 255 |
|---|---|---|---|---|
| master `<SP>` count | 56217 | 51872 | 51872 | 51872 |
| with this PR | 51586 | 51586 | 51586 | 51586 |

It also varied with ASLR between plain runs, and — the clearest demonstration —
purely with the length of the output path, because that changes the heap layout:

```
same binary, same PDF, output /tmp/a.xml          -> md5 43483d9e8f
same binary, same PDF, output /tmp/aaaa...aaa.xml -> md5 7d6d488535
```

With the fix both produce identical output.

The spurious `<SP>` elements often had negative `WIDTH`. #236 (commit 218af15) clamps
those to zero, which addressed the symptom; this addresses the cause. That clamp is
still needed and is not touched here — after this fix, negative inter-word gaps drop
from 5435 to 758 across a 14-PDF sample, the remainder being genuine word overlap
from backward kerning and reordered runs, exactly as #236 describes.

## 2. Font metrics read through a freed `GfxFont`

`TextWord` and `TextRawWord` took their ascent and descent by dereferencing
`font->gfxFont`. That `GfxFont` belongs to the resource dictionary of the content
stream that drew the text, so when the text sits inside a form XObject the font is
destroyed by `GfxFontDict::~GfxFontDict()` as soon as `Gfx::popResources()` runs for
that form, while the words built from it live on until the page is dumped.

AddressSanitizer on `grobid-04-2015.pdf`:

```
READ of size 8 in TextRawWord::TextRawWord   XmlAltoOutputDev.cc:1027
freed by GfxFontDict::~GfxFontDict           xpdf/GfxFont.cc:2351
  <- GfxResources::~GfxResources / Gfx::popResources / Gfx::drawForm
```

The reachable instance is the `TextRawWord` one, which is what ASan catches above; the
identical `TextWord` constructor is fixed alongside it, though that class is currently
unreachable (see above).

`TextFontInfo` already captures ascent and descent in its own constructor, while the
font is still alive, so this reads those instead and never dereferences the stored
pointer. `GfxFont` is not reference counted, so caching the values is the only option
available. The cached copies are also the sanitised ones — `TextFontInfo` clamps the
"odd" values that buggy generators emit, which the raw `getAscent()`/`getDescent()`
calls bypassed.

## Verification

- 14-PDF corpus: output byte-identical across `MALLOC_PERTURB_` 0/1/170/255 and across
  repeated unpinned runs. Extracted text unchanged throughout; only the spurious `<SP>`
  elements disappear (`korean_document.pdf` 56237 -> 51586).
- AddressSanitizer across 4 PDFs: 1 use-after-free before, 0 after.
- Both commits build standalone.

## Note on ordering

This is worth landing before the other open pdfalto branches. Because any two
differently-compiled builds read different garbage, branch-vs-master output diffs on
current master are dominated by build-layout noise rather than by the branch's own
changes — in one measurement a branch that only adds a `strstr()` call appeared to
move a coordinate by 6.4e8. With this merged, that noise floor goes away and the other
branches can actually be evaluated.

## Behaviour change for reviewers

This changes `<SP>` output on real documents (fewer elements). The removed ones were
produced from uninitialised memory, and extracted text is unaffected — but anything
downstream with baked-in expectations of `<SP>` counts will shift.