### PR TITLE
Drive superscript token boundary from pdfalto's own detection

### DIFF
--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -6630,25 +6630,29 @@ void TextPage::dump(GBool noLineNumbers, GBool fullFontName, const vector<bool> 
                     // word with no space character in the content stream otherwise merges
                     // into it ("developed13-15", "Kowalczyk1,2,*"); strict letter/digit
                     // tokenizers (e.g. GROBID's) will not split that, hiding the callout.
-                    // The smaller-font neighbour is the scripted run; it is a SUPERscript
-                    // when its baseline is raised relative to the baseline word. Subscripts
-                    // (lowered — e.g. the "2" in a chemical formula "CO2") are deliberately
-                    // NOT separated, so formulae stay intact. Adjacent words are tested
-                    // directly to avoid depending on the running-line-baseline state.
-                    bool scriptBoundary = false;
-                    if (nextWord != NULL && word->fontSize > 0 && nextWord->fontSize > 0 &&
-                        word->fontSize != nextWord->fontSize) {
-                        bool wordSmaller = word->fontSize < nextWord->fontSize;
-                        double larger  = wordSmaller ? nextWord->fontSize : word->fontSize;
-                        double smaller = wordSmaller ? word->fontSize : nextWord->fontSize;
-                        double scriptBase   = wordSmaller ? word->base : nextWord->base;
-                        double baselineBase = wordSmaller ? nextWord->base : word->base;
-                        // markedly smaller font, and the scripted run's baseline raised
-                        // (base value smaller => higher on the page) => superscript.
-                        if (smaller <= 0.85 * larger &&
-                            (baselineBase - scriptBase) >= 0.15 * larger)
-                            scriptBoundary = true;
+                    //
+                    // Reuse pdfalto's own superscript detection rather than an ad-hoc
+                    // font-size ratio: the current word's flag was already computed above
+                    // (fontStyleInfo), and the next word is tested against the same
+                    // line-baseline criteria. The running currentLineBaseLine is only
+                    // updated *after* this point, so fold in the current word's
+                    // contribution first: a baseline current word defines the baseline the
+                    // next word is measured against (this is what fixes the case where the
+                    // callout is the word right after the name, e.g. "Zanke5"). Subscripts
+                    // (lowered, e.g. the "2" in "CO2") never satisfy the superscript test,
+                    // so chemical formulae stay intact.
+                    double effBaseLine = currentLineBaseLine;
+                    double effYmin = currentLineYmin;
+                    if (!fontStyleInfo->isSuperscript() && !fontStyleInfo->isSubscript()) {
+                        effBaseLine = word->base;
+                        effYmin = word->yMin;
                     }
+                    bool curIsSuper = fontStyleInfo->isSuperscript();
+                    bool nextIsSuper = (nextWord != NULL && effBaseLine != 0 &&
+                                        nextWord->base < effBaseLine &&
+                                        nextWord->yMax > effYmin &&
+                                        nextWord->fontSize < lineFontSize);
+                    bool scriptBoundary = (nextWord != NULL) && (curIsSuper != nextIsSuper);
 
                     if (wordI < line1->words->getLength() - 1 and (word->spaceAfter == gTrue or scriptBoundary)) {
                         xmlNodePtr spacingNode = xmlNewNode(NULL, (const xmlChar *) TAG_SPACING);

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -550,8 +550,10 @@ public:
     /** The number of content stream characters in this word */
     int charLen;
 
-    GBool spaceAfter;		// set if there is a space between this
-    //   word and the next word on the line
+    GBool spaceAfter = gFalse;	// set if there is a space between this
+    //   word and the next word on the line. Default-initialised: it is set true
+    //   only when a space character follows, so an unassigned value would make
+    //   <SP> emission depend on heap contents (see #248).
 
     /** <code>true</code> if the current <code>TextRawWord</code> is <b>bold</b>, <code>false</code> else */
     GBool  bold;


### PR DESCRIPTION
<= 0.85*larger + baseline shift). Replace it with pdfalto's existing per-word superscript detection so the boundary is consistent by construction with the FONTSTYLE="superscript" already emitted, and there are no magic thresholds.

The subtlety is timing: the boundary between word i and i+1 is decided while processing word i, before i+1's flag exists, and the running currentLineBaseLine is only updated *after* this point. So fold the current word's contribution into an effective baseline first (a baseline current word defines the baseline the next word is measured against). This fixes callouts that are the word right after the name, e.g. 'Zanke5' -> 'Zanke 5', which a next-word re-derivation with the stale baseline missed. Subscripts never satisfy the superscript test, so 'CO2' stays joined.

Also give IWord::spaceAfter an in-class default initialiser: it is only ever set true (on a following space char), so an unassigned value made <SP> emission depend on heap contents (the root of #248); the default prevents recurrence in any future constructor/path.