### PR TITLE
Add -discardClippedText: drop glyphs entirely outside the current clip path

### DIFF
--- a/src/Parameters.cc
+++ b/src/Parameters.cc
@@ -15,6 +15,7 @@ Parameters::Parameters() {
   vectorCoordsOnly = gFalse;
   vectorPathLimit = 0;
   vectorBoxes = gFalse;
+  discardClippedText = gFalse;
 }
 
 Parameters::~Parameters() {}
@@ -71,6 +72,12 @@ void Parameters::setFullFontName(GBool fullFontsNames) {
 void Parameters::setReadingOrder(GBool readingOrders) {
   lockGlobalParams;
   readingOrder = readingOrders;
+  unlockGlobalParams;
+}
+
+void Parameters::setDiscardClippedText(GBool discardClippedTextA) {
+  lockGlobalParams;
+  discardClippedText = discardClippedTextA;
   unlockGlobalParams;
 }
 

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -74,6 +74,13 @@ public:
 	 */
 	GBool getReadingOrder() {return readingOrder;}
 
+	/** Return whether characters whose glyph box lies entirely outside the current clip
+	 *  path are discarded (text hidden inside clipped Form XObjects, e.g. manuscript text
+	 *  carried along by embedded figure PDFs).
+	 * @return <code>true</code> if the discardClippedText option is selected
+	 */
+	GBool getDiscardClippedText() {return discardClippedText;}
+
 	/** PL: Return the boolean that controls whether to include TYPE attributes to String elements to
 	 * indicate right-to-left reading order (produces non-valid ALTO)
 	 * @return <code>true</code> if the charReadingOrderAttr option is selected, <code>false</code> otherwise
@@ -160,6 +167,9 @@ public:
 	 */	
 	void setReadingOrder(GBool readingOrders);
 
+	/** Set whether fully clipped characters are discarded (see getDiscardClippedText) */
+	void setDiscardClippedText(GBool discardClippedTextA);
+
 	/** PL: Modifiy the boolean that controls whether to include TYPE attributes to String elements to indicate
 	 * right-to-left reading order (produces non-valid ALTO)
 	 * @param charReadingOrderAttr <code>true</code> if the charReadingOrderAttr option is selected, <code>false</code> otherwise
@@ -214,6 +224,9 @@ private:
 	//GBool imageInline;
 	/** PL: The value of the readingOrder option */
 	GBool readingOrder;
+
+	/** The value of the discardClippedText option */
+	GBool discardClippedText;
 	/** PL: The value of the charReadingOrderAttr option */
 	GBool charReadingOrderAttr;
 	/** The value of ocr option */

--- a/src/XmlAltoOutputDev.cc
+++ b/src/XmlAltoOutputDev.cc
@@ -3009,9 +3009,51 @@ void TextPage::addCharToRawWord(GfxState *state, double x, double y, double dx,
         curWord = NULL;
 }
 
+// Is the glyph drawn at (x,y) with advance (dx,dy) entirely outside the current clip path?
+// Mirrors the (disabled) xpdf discardClippedText test: the midpoint of the rotation-aware
+// glyph box is compared against the device-space clip bounding box. Typical case: a figure
+// embedded as a PDF Form XObject whose content stream still carries the text of the page it
+// was exported from, clipped to the figure rectangle -- invisible when rendered, but present
+// in the content stream and therefore duplicated in the extraction.
+GBool TextPage::isClippedOut(GfxState *state, double x, double y, double dx, double dy) {
+    double x1, y1, w1, h1, xMid, yMid, ascent, descent;
+    double clipXMin, clipYMin, clipXMax, clipYMax;
+
+    state->transform(x, y, &x1, &y1);
+    state->transformDelta(dx, dy, &w1, &h1);
+    ascent = curFont ? curFont->ascent * curFontSize : 0.0;
+    descent = curFont ? curFont->descent * curFontSize : 0.0;
+    switch (curRot) {
+        case 0:
+        default:
+            xMid = x1 + 0.5 * w1;
+            yMid = y1 - 0.5 * (ascent + descent);
+            break;
+        case 1:
+            xMid = x1 + 0.5 * (ascent + descent);
+            yMid = y1 + 0.5 * h1;
+            break;
+        case 2:
+            xMid = x1 + 0.5 * w1;
+            yMid = y1 + 0.5 * (ascent + descent);
+            break;
+        case 3:
+            xMid = x1 - 0.5 * (ascent + descent);
+            yMid = y1 + 0.5 * h1;
+            break;
+    }
+    state->getClipBBox(&clipXMin, &clipYMin, &clipXMax, &clipYMax);
+    return (xMid < clipXMin || xMid > clipXMax || yMid < clipYMin || yMid > clipYMax);
+}
+
 void TextPage::addChar(GfxState *state, double x, double y, double dx,
                        double dy, CharCode c, int nBytes, Unicode *u, int uLen, SplashFont *splashFont,
                        GBool isNonUnicodeGlyph) {
+    if (parameters->getDiscardClippedText() && isClippedOut(state, x, y, dx, dy)) {
+        // keep charPos in sync with the content stream even for dropped glyphs
+        charPos += nBytes;
+        return;
+    }
 //    if (parameters->getReadingOrder() == gTrue)
 //        addCharToPageChars(state, x, y, dx, dy, c, nBytes, u, uLen, splashFont, isNonUnicodeGlyph);
 //    else

--- a/src/XmlAltoOutputDev.h
+++ b/src/XmlAltoOutputDev.h
@@ -973,6 +973,9 @@ public:
                  double dx, double dy,
                  CharCode c, int nBytes, Unicode *u, int uLen, SplashFont * splashFont, GBool isNonUnicodeGlyph);
 
+    /** True if the glyph at (x,y) with advance (dx,dy) lies entirely outside the current clip path */
+    GBool isClippedOut(GfxState *state, double x, double y, double dx, double dy);
+
     /** Add a character to the list of characters in the page
      *  @param state The state description
      *  @param x The x value of left bottom corner of the box character

--- a/src/pdfalto.cc
+++ b/src/pdfalto.cc
@@ -71,6 +71,7 @@ static GBool noImageInline = gFalse;
 
 static GBool annots = gFalse;
 static GBool readingOrder = gFalse;
+static GBool discardClippedText = gFalse;
 static GBool charReadingOrderAttr = gFalse;
 static GBool ocr = gFalse;
 
@@ -115,6 +116,8 @@ static ArgDesc argDesc[] = {
                 "do not output line numbers added in manuscript-style textual documents"},
         {"-readingOrder",  argFlag,   &readingOrder,    0,
                 "blocks follow the reading order"},
+        {"-discardClippedText", argFlag, &discardClippedText, 0,
+                "drop characters whose glyph lies entirely outside the current clip path (hidden text inside clipped Form XObjects, e.g. manuscript text carried by embedded figure PDFs)"},
         {"-noText",        argFlag,   &noText,          0,
                 "do not extract textual objects (might be useful, but non-valid ALTO)"},
         {"-charReadingOrderAttr",  argFlag,   &charReadingOrderAttr,    0,
@@ -299,6 +302,13 @@ int main(int argc, char *argv[]) {
         cmd->append("-readingOrder ");
     } else {
         parameters->setReadingOrder(gFalse);
+    }
+
+    if (discardClippedText) {
+        parameters->setDiscardClippedText(gTrue);
+        cmd->append("-discardClippedText ");
+    } else {
+        parameters->setDiscardClippedText(gFalse);
     }
 
     if (charReadingOrderAttr) {


### PR DESCRIPTION
Figures embedded as PDF Form XObjects frequently carry the text of the page they were exported from, clipped to the figure rectangle. The text never renders but is present in the content stream, so it was emitted as ordinary words: whole paragraphs and section headings duplicated two or three times (60% of an MDPI materials-science corpus of 2,595 articles was affected).

The xpdf clip test was present but commented out. This re-introduces it at TextPage::addChar (the only live path) behind a new -discardClippedText flag, using the rotation-aware glyph-box midpoint against the device-space clip bounding box, exactly as xpdf's discardClippedText does. Default behaviour is unchanged.